### PR TITLE
[refactor] 메인 페이지 UI 글로벌 스타일 적용

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -9,7 +9,8 @@ import {
 import { colors } from '@/style/themes';
 
 const NavContainer = styled.nav`
-  position: fixed;
+  position: center;
+  width: 720px;
   bottom: 0;
   left: 0;
   right: 0;
@@ -43,7 +44,7 @@ const BottomNav = () => {
   const navigate = useNavigate();
   const location = useLocation();
   {
-    /*추후 로직 수정 예정 */
+    /*추후 로직 수정 예정 - 속한 모임 있는지 없는지 여부 */
   }
   const userIsInGroup = true;
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { Overlay, OVERLAY_ANIMATION_DURATION } from '@/components/common/Overlay';
 import { RoomCreateButton } from '@/components/home_page/RoomCreateButton';
 import BottomNav from '@/components/common/BottomNav';
+import { Container } from '@/style/CommonStyle';
 declare global {
   interface Window {
     kakao: any;
@@ -28,20 +29,15 @@ const MarkerStyles = createGlobalStyle`
     background: #fff; position: absolute; border-radius: 50%; }
 `;
 
-const HomeContainer = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 60px;
-  display: flex;
-  flex-direction: column;
+const HomePageContainer = styled(Container)`
+  justify-content: space-between;
 `;
 
 const MapArea = styled.div`
   flex: 1;
   position: relative;
   overflow: hidden;
+  width: 100%;
 `;
 
 const MapContainer = styled.div.attrs({ id: 'kakaoMap' })`
@@ -70,15 +66,15 @@ const Home = () => {
       <GlobalStyle />
       <KakaoMapCssFix />
       <MarkerStyles />
-      <HomeContainer>
+      <HomePageContainer>
         <MapArea>
           <SearchButton onClick={handleSearchClick} />
           <MapContainer ref={mapRef} />
           <RoomCreateButton to="/create-room" />
+          {isSearchOpen && <Overlay />}
         </MapArea>
-        {isSearchOpen && <Overlay />}
-      </HomeContainer>
-      <BottomNav />
+        <BottomNav />
+      </HomePageContainer>
     </>
   );
 };


### PR DESCRIPTION
## 📝 PR 유형
- [ ] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용
1. 메인페이지의 가로너비와 아래 메뉴 컴포넌트를 글로벌 스타일 UI에 맞췄습니다! 
<img width="1920" height="877" alt="image" src="https://github.com/user-attachments/assets/a56245c7-0365-4c23-a103-3363bb0c5dbd" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #23

## 💬 기타 사항


## 📂 참고 자료

> N/A
