### PR TITLE
[부산대 2팀_FE] Release/2025-10-17

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
   deploy:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,3 +52,14 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Invalidate CloudFront cache
+        run: |
+          echo "Invalidating CloudFront cache..."
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.DISTRIBUTION_ID }} \
+            --paths "/*"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,10 @@ jobs:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
           VITE_KAKAO_MAP_KEY: ${{ secrets.VITE_KAKAO_MAP_KEY }}
 
-      - name: Sync files to S3
+      - name: Sync static assets (JS, CSS, images)
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --delete
+          args: --delete --exclude "*.html"
         env:
           AWS_S3_BUCKET: ${{ secrets.S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,18 +44,22 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: 'dist'
 
-      - name: Invalidate CloudFront
-        uses: chetan/invalidate-cloudfront-action@v2
+      - name: Upload HTML files (no-cache)
+        run: |
+          aws s3 cp dist s3://${{ secrets.S3_BUCKET }}/ \
+            --recursive \
+            --exclude "*" \
+            --include "*.html" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html" \
+            --metadata-directive REPLACE
         env:
-          DISTRIBUTION: ${{ secrets.DISTRIBUTION_ID }}
-          PATHS: '/*'
-          AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
 
       - name: Invalidate CloudFront cache
         run: |
-          echo "Invalidating CloudFront cache..."
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.DISTRIBUTION_ID }} \
             --paths "/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,6 +2688,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3468,6 +3479,12 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3520,6 +3537,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3556,6 +3579,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/isexe": {
@@ -3698,6 +3731,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3820,6 +3863,17 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.23",
@@ -3989,6 +4043,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -4318,6 +4378,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4367,6 +4447,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/sockjs-client": {
@@ -4520,6 +4611,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -4582,6 +4680,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4869,6 +4980,29 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@reduxjs/toolkit": "^2.8.2",
         "@stomp/stompjs": "^7.2.0",
         "axios": "^1.12.2",
+        "framer-motion": "^12.23.22",
         "js-cookie": "^3.0.5",
         "react": "^19.1.1",
         "react-component": "^0.0.0",
@@ -1309,9 +1310,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.48.1.tgz",
-      "integrity": "sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
       "cpu": [
         "arm"
       ],
@@ -1323,9 +1324,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.48.1.tgz",
-      "integrity": "sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
       "cpu": [
         "arm64"
       ],
@@ -1337,9 +1338,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.48.1.tgz",
-      "integrity": "sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
       "cpu": [
         "arm64"
       ],
@@ -1351,9 +1352,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.48.1.tgz",
-      "integrity": "sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
       "cpu": [
         "x64"
       ],
@@ -1365,9 +1366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.48.1.tgz",
-      "integrity": "sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
       "cpu": [
         "arm64"
       ],
@@ -1379,9 +1380,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.48.1.tgz",
-      "integrity": "sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
       "cpu": [
         "x64"
       ],
@@ -1393,9 +1394,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.48.1.tgz",
-      "integrity": "sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
       "cpu": [
         "arm"
       ],
@@ -1407,9 +1408,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.48.1.tgz",
-      "integrity": "sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
       "cpu": [
         "arm"
       ],
@@ -1421,9 +1422,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.48.1.tgz",
-      "integrity": "sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
       "cpu": [
         "arm64"
       ],
@@ -1435,9 +1436,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.48.1.tgz",
-      "integrity": "sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
       "cpu": [
         "arm64"
       ],
@@ -1448,10 +1449,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.48.1.tgz",
-      "integrity": "sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
       "cpu": [
         "loong64"
       ],
@@ -1463,9 +1464,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.48.1.tgz",
-      "integrity": "sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
       "cpu": [
         "ppc64"
       ],
@@ -1477,9 +1478,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.48.1.tgz",
-      "integrity": "sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
       "cpu": [
         "riscv64"
       ],
@@ -1491,9 +1492,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.48.1.tgz",
-      "integrity": "sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
       "cpu": [
         "riscv64"
       ],
@@ -1505,9 +1506,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.48.1.tgz",
-      "integrity": "sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
       "cpu": [
         "s390x"
       ],
@@ -1519,9 +1520,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.1.tgz",
-      "integrity": "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
       "cpu": [
         "x64"
       ],
@@ -1533,9 +1534,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.1.tgz",
-      "integrity": "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
       "cpu": [
         "x64"
       ],
@@ -1546,10 +1547,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.48.1.tgz",
-      "integrity": "sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
       "cpu": [
         "arm64"
       ],
@@ -1561,9 +1576,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.48.1.tgz",
-      "integrity": "sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
       "cpu": [
         "ia32"
       ],
@@ -1574,10 +1589,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.48.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.48.1.tgz",
-      "integrity": "sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==",
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
       "cpu": [
         "x64"
       ],
@@ -1973,17 +2002,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
-      "integrity": "sha512-w/EboPlBwnmOBtRbiOvzjD+wdiZdgFeo17lkltrtn7X37vagKKWJABvyfsJXTlHe6XBzugmYgd4A4nW+k8Mixw==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
+      "integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/type-utils": "8.40.0",
-        "@typescript-eslint/utils": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/scope-manager": "8.46.1",
+        "@typescript-eslint/type-utils": "8.46.1",
+        "@typescript-eslint/utils": "8.46.1",
+        "@typescript-eslint/visitor-keys": "8.46.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1997,7 +2026,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.40.0",
+        "@typescript-eslint/parser": "^8.46.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -2013,16 +2042,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.40.0.tgz",
-      "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
+      "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/scope-manager": "8.46.1",
+        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/typescript-estree": "8.46.1",
+        "@typescript-eslint/visitor-keys": "8.46.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2038,14 +2067,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.40.0.tgz",
-      "integrity": "sha512-/A89vz7Wf5DEXsGVvcGdYKbVM9F7DyFXj52lNYUDS1L9yJfqjW/fIp5PgMuEJL/KeqVTe2QSbXAGUZljDUpArw==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
+      "integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.40.0",
-        "@typescript-eslint/types": "^8.40.0",
+        "@typescript-eslint/tsconfig-utils": "^8.46.1",
+        "@typescript-eslint/types": "^8.46.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2060,14 +2089,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.40.0.tgz",
-      "integrity": "sha512-y9ObStCcdCiZKzwqsE8CcpyuVMwRouJbbSrNuThDpv16dFAj429IkM6LNb1dZ2m7hK5fHyzNcErZf7CEeKXR4w==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
+      "integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0"
+        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/visitor-keys": "8.46.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2078,9 +2107,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.40.0.tgz",
-      "integrity": "sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
+      "integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2095,15 +2124,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.40.0.tgz",
-      "integrity": "sha512-eE60cK4KzAc6ZrzlJnflXdrMqOBaugeukWICO2rB0KNvwdIMaEaYiywwHMzA1qFpTxrLhN9Lp4E/00EgWcD3Ow==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
+      "integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0",
-        "@typescript-eslint/utils": "8.40.0",
+        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/typescript-estree": "8.46.1",
+        "@typescript-eslint/utils": "8.46.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2120,9 +2149,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.40.0.tgz",
-      "integrity": "sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
+      "integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2134,16 +2163,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.40.0.tgz",
-      "integrity": "sha512-k1z9+GJReVVOkc1WfVKs1vBrR5MIKKbdAjDTPvIK3L8De6KbFfPFt6BKpdkdk7rZS2GtC/m6yI5MYX+UsuvVYQ==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
+      "integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.40.0",
-        "@typescript-eslint/tsconfig-utils": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/project-service": "8.46.1",
+        "@typescript-eslint/tsconfig-utils": "8.46.1",
+        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/visitor-keys": "8.46.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2189,9 +2218,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2202,16 +2231,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.40.0.tgz",
-      "integrity": "sha512-Cgzi2MXSZyAUOY+BFwGs17s7ad/7L+gKt6Y8rAVVWS+7o6wrjeFN4nVfTpbE25MNcxyJ+iYUXflbs2xR9h4UBg==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
+      "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0"
+        "@typescript-eslint/scope-manager": "8.46.1",
+        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/typescript-estree": "8.46.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2226,13 +2255,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.40.0.tgz",
-      "integrity": "sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==",
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
+      "integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/types": "8.46.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2657,17 +2686,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -3249,21 +3267,1661 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-component": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/react-component/-/react-component-0.0.0.tgz",
+      "integrity": "sha512-BhUOsgimfA/1iI8zL3VNsfEkSNM1Dd43P5w6gFfj8c6nIhSmTQVSzHnWus+M3u6VnfIUhAp+5H6aKGPYYJ7Ggg==",
+      "license": "MIT"
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
+      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
+      "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-components": {
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/styled-components/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "license": "MIT"
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.46.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
+      "integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.46.1",
+        "@typescript-eslint/parser": "8.46.1",
+        "@typescript-eslint/typescript-estree": "8.46.1",
+        "@typescript-eslint/utils": "8.46.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.10.tgz",
+      "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-svgr": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.5.0.tgz",
+      "integrity": "sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.2.0",
+        "@svgr/core": "^8.1.0",
+        "@svgr/plugin-jsx": "^8.1.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.6.0"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "peerDependencies": {
-      "@emotion/is-prop-valid": "*",
-      "react": "^18.0.0 || ^19.0.0",
-      "react-dom": "^18.0.0 || ^19.0.0"
+      "extraneous": true
     },
     "peerDependenciesMeta": {
-      "@emotion/is-prop-valid": {
-        "optional": true
-      },
-      "react": {
-        "optional": true
-      },
-      "react-dom": {
-        "optional": true
-      }
+      "extraneous": true
     }
   },
   "node_modules/fsevents": {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -20,9 +20,25 @@ const createProfileFormData = async (profileData: MyProfileState): Promise<FormD
     }
   }
 
-  // baseLocation 처리(임시방편임!! 추후 수정 필요)
+  // baseLocation 처리
   if (profileData.baseLocation) {
-    formData.append('baseLocation.baseLocationId', '26410');
+    // baseLocation이 문자열인 경우 (예: "부산광역시 금정구")
+    if (typeof profileData.baseLocation === 'string') {
+      const locationParts = profileData.baseLocation.split(' ');
+      if (locationParts.length >= 2) {
+        formData.append('baseLocation.sidoName', locationParts[0]);
+        formData.append('baseLocation.sigunguName', locationParts[1]);
+      }
+    }
+    // baseLocation이 객체인 경우
+    else if (typeof profileData.baseLocation === 'object') {
+      if (profileData.baseLocation.sidoName) {
+        formData.append('baseLocation.sidoName', profileData.baseLocation.sidoName);
+      }
+      if (profileData.baseLocation.sigunguName) {
+        formData.append('baseLocation.sigunguName', profileData.baseLocation.sigunguName);
+      }
+    }
   }
 
   // 이미지 필드 처리
@@ -110,7 +126,7 @@ export const updateProfile = async (profileData: MyProfileState) => {
     }
     console.log('원본 데이터:', profileData);
 
-    const response = await api.put('/api/profiles/me', formData, {
+    const response = await api.patch('/api/profiles/me', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
@@ -155,6 +171,18 @@ export const signup = async (email: string, password1: string, password2: string
     return res.data;
   } catch (error: any) {
     console.error('회원가입 실패:', error);
+    throw error;
+  }
+};
+
+// 로그아웃 API
+export const logout = async () => {
+  try {
+    const res = await api.post('/api/auth/logout');
+    console.log('로그아웃 성공:', res.data);
+    return res.data;
+  } catch (error: any) {
+    console.error('로그아웃 실패:', error);
     throw error;
   }
 };

--- a/src/api/badge.ts
+++ b/src/api/badge.ts
@@ -1,0 +1,15 @@
+import api from './axiosInstance';
+import type { BadgeListResponse } from '@/types/badge';
+
+// 내 뱃지 조회 API
+export const getMyBadges = async (): Promise<BadgeListResponse> => {
+  try {
+    const response = await api.get<BadgeListResponse>('/api/profiles/me/badges');
+    console.log('뱃지 조회 성공:', response.data);
+    return response.data;
+  } catch (error: any) {
+    console.error('뱃지 조회 실패:', error);
+    throw error;
+  }
+};
+

--- a/src/api/clients/publicApi.ts
+++ b/src/api/clients/publicApi.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 
 const publicApi = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/api/main_meetings.ts
+++ b/src/api/main_meetings.ts
@@ -2,8 +2,7 @@ import api from './axiosInstance';
 import type { Meeting } from '@/types/meeting';
 
 interface GetMeetingsParams {
-  name?: string;
-  hobby?: string;
+  category?: string;
   latitude: number;
   longitude: number;
   radius: number;

--- a/src/api/meeting_list.ts
+++ b/src/api/meeting_list.ts
@@ -1,20 +1,20 @@
 import api from './axiosInstance';
 import type { Meeting } from '@/types/meeting';
 
-interface GetMeetingsParams {
+export interface GetMeetingsParams {
   name?: string;
   hobby?: string;
-  latitude: number;
-  longitude: number;
-  radius: number;
+  latitude?: number;
+  longitude?: number;
+  radius?: number;
 }
 
 export const getMeetings = async (params: GetMeetingsParams): Promise<Meeting[]> => {
   try {
-    const response = await api.get('/api/meetings', { params });
+    const response = await api.get<Meeting[]>('/api/meetings', { params });
     return response.data;
   } catch (error) {
-    console.error('주변 모임 목록 조회 실패:', error);
+    console.error('모임 목록 조회 실패:', error);
     throw error;
   }
 };

--- a/src/api/services/auth.service.ts
+++ b/src/api/services/auth.service.ts
@@ -1,0 +1,18 @@
+import { getAccessToken } from '@/utils/tokenStorage';
+import publicApi from '../clients/publicApi';
+import type { MeetupRequestDTO } from '../types/meeting_room.dto';
+
+export const getUgradeToken = async (body: MeetupRequestDTO) => {
+  try {
+    const accessToken = getAccessToken();
+    const response = await publicApi.post('/api/auth/ws-upgrade', body, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    console.error('업그레이드 토큰 요청 실패:', error);
+    throw error;
+  }
+};

--- a/src/api/services/meeting_room.service.ts
+++ b/src/api/services/meeting_room.service.ts
@@ -1,0 +1,210 @@
+import { getAccessToken } from '@/utils/tokenStorage';
+import publicApi from '../clients/publicApi';
+import type { MeetupRequestDTO, MeetupResponseDto } from '../types/meeting_room.dto';
+
+export const createMeetUp = async (body: MeetupRequestDTO) => {
+  try {
+    const accessToken = getAccessToken();
+    const response = await publicApi.post<MeetupResponseDto>('/api/meetups', body, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    console.error('미팅룸 생성 요청 실패:', error);
+    if (error.response) {
+      // 네트워크 에러 처리
+      if (error.response.status === 0) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 인증 에러 처리
+      if (error.response.status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      }
+      // 권한 에러 처리
+      if (error.response.status === 403) {
+        throw new Error('권한이 없습니다. 접근이 거부되었습니다.');
+      }
+      // 리소스 없음 처리
+      if (error.response.status === 404) {
+        throw new Error('요청한 리소스를 찾을 수 없습니다.');
+      }
+      // 서버 에러 처리
+      if (error.response.status >= 500) {
+        throw new Error('서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 기타 에러 처리
+      if (error.response.data && (error.response.data.detail || error.response.data.message)) {
+        const errorMessage = error.response.data.detail || error.response.data.message;
+        throw new Error(errorMessage);
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } else {
+      // 요청이 아예 서버에 도달하지 못한 경우
+      if (error.request) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  }
+};
+
+export const joinMeetUp = async (meetUpId: string) => {
+  try {
+    const accessToken = getAccessToken();
+    const response = await publicApi.post(
+      `/api/meetups/${meetUpId}/participants`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    return response.data;
+  } catch (error: any) {
+    console.error('모임 참가 요청 실패:', error);
+    if (error.response) {
+      // 네트워크 에러 처리
+      if (error.response.status === 0) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 인증 에러 처리
+      if (error.response.status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      }
+      // 권한 에러 처리
+      if (error.response.status === 403) {
+        throw new Error('권한이 없습니다. 접근이 거부되었습니다.');
+      }
+      // 리소스 없음 처리
+      if (error.response.status === 404) {
+        throw new Error('요청한 리소스를 찾을 수 없습니다.');
+      }
+      // 서버 에러 처리
+      if (error.response.status === 409) {
+        throw new Error('이미 모임에 참여 중입니다.');
+      }
+      if (error.response.status >= 500) {
+        throw new Error('서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 기타 에러 처리
+      if (error.response.data && (error.response.data.detail || error.response.data.message)) {
+        const errorMessage = error.response.data.detail || error.response.data.message;
+        throw new Error(errorMessage);
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } else {
+      // 요청이 아예 서버에 도달하지 못한 경우
+      if (error.request) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  }
+};
+
+export const getMyJoinedMeetup = async () => {
+  try {
+    const accessToken = getAccessToken();
+    const response = await publicApi.get('/api/meetups/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    console.error('나의 참여 모임 정보 조회 실패:', error);
+    if (error.response) {
+      // 네트워크 에러 처리
+      if (error.response.status === 0) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 인증 에러 처리
+      if (error.response.status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      }
+      // 권한 에러 처리
+      if (error.response.status === 403) {
+        throw new Error('권한이 없습니다. 접근이 거부되었습니다.');
+      }
+      // 리소스 없음 처리
+      if (error.response.status === 404) {
+        throw new Error('요청한 리소스를 찾을 수 없습니다.');
+      }
+      // 서버 에러 처리
+      if (error.response.status >= 500) {
+        throw new Error('서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 기타 에러 처리
+      if (error.response.data && (error.response.data.detail || error.response.data.message)) {
+        const errorMessage = error.response.data.detail || error.response.data.message;
+        throw new Error(errorMessage);
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } else {
+      // 요청이 아예 서버에 도달하지 못한 경우
+      if (error.request) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  }
+};
+
+export const leaveMeetUp = async (meetUpId: string) => {
+  try {
+    const accessToken = getAccessToken();
+    const response = await publicApi.delete(`/api/meetups/${meetUpId}/participants`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    console.error('모임 나가기 실패:', error);
+    if (error.response) {
+      // 네트워크 에러 처리
+      if (error.response.status === 0) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 인증 에러 처리
+      if (error.response.status === 401) {
+        throw new Error('인증이 필요합니다. 다시 로그인해주세요.');
+      }
+      // 권한 에러 처리
+      if (error.response.status === 403) {
+        throw new Error('권한이 없습니다. 접근이 거부되었습니다.');
+      }
+      // 리소스 없음 처리
+      if (error.response.status === 404) {
+        throw new Error('요청한 리소스를 찾을 수 없습니다.');
+      }
+      // 서버 에러 처리
+      if (error.response.status >= 500) {
+        throw new Error('서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+      // 기타 에러 처리
+      if (error.response.data && (error.response.data.detail || error.response.data.message)) {
+        const errorMessage = error.response.data.detail || error.response.data.message;
+        throw new Error(errorMessage);
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } else {
+      // 요청이 아예 서버에 도달하지 못한 경우
+      if (error.request) {
+        throw new Error('서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.');
+      } else {
+        throw new Error('알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  }
+};

--- a/src/api/services/mockBodyData.ts
+++ b/src/api/services/mockBodyData.ts
@@ -1,0 +1,15 @@
+export const body = {
+  name: '부산대 근처에서 같이 밥 먹어요!',
+  category: 'FOOD',
+  subCategory: 'RICE',
+  description: '부산대 근처에서 점심 같이 먹을 사람 구해요! 혼밥 싫은 분 환영합니다.',
+  hashTags: ['밥', '식사', '친목'],
+  capacity: 5,
+  scoreLimit: 0,
+  durationHours: 2,
+  location: {
+    latitude: 35.23203443995263,
+    longitude: 129.08262659183725,
+    address: '부산광역시 금정구 부산대학로 63번길 2',
+  },
+};

--- a/src/api/types/meeting_room.dto.ts
+++ b/src/api/types/meeting_room.dto.ts
@@ -1,0 +1,68 @@
+export interface Owner {
+  id: string;
+  nickname: string;
+  age: number;
+  gender: 'MALE' | 'FEMALE';
+  imageUrl: string;
+  description: string;
+  baseLocationId: number;
+  baseLocation: string;
+  temperature: number;
+  likes: number;
+  dislikes: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Sigungu {
+  sidoName: string;
+  sidoCode: number;
+  sigunguName: string;
+  sigunguCode: number;
+  baseLocation: BaseLocation;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BaseLocation {
+  longitude: number;
+  latitude: number;
+  address: string;
+}
+
+export interface Location {
+  longitude: number;
+  latitude: number;
+  address: string;
+}
+
+export interface MeetupRequestDTO {
+  name: string;
+  category: string;
+  subCategory: string;
+  description: string;
+  hashTags: string[];
+  capacity: number;
+  scoreLimit: number;
+  durationHours: number;
+  location: Location;
+}
+
+export interface MeetupResponseDto {
+  id: string;
+  name: string;
+  category: string;
+  subCategory: string;
+  description: string;
+  participantCount: number;
+  capacity: number;
+  scoreLimit: number;
+  owner: Owner;
+  sigungu: Sigungu;
+  location: Location;
+  hashTags: string[];
+  status: string;
+  endAt: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/components/home_page/MapFilters.tsx
+++ b/src/components/home_page/MapFilters.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import { colors } from '@/style/themes';
+
+const FiltersContainer = styled.div`
+  position: absolute;
+  top: 75px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  width: 100%;
+  max-width: calc(100% - 32px);
+  overflow-x: auto;
+  white-space: nowrap;
+  text-align: center;
+  padding-bottom: 8px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
+
+const FilterButton = styled.button`
+  display: inline-block;
+  margin: 0 4px;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: rgba(255, 255, 255, 0.95);
+  cursor: pointer;
+  font-size: 0.9rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s ease-in-out;
+
+  &.selected {
+    background-color: ${colors.primary400};
+    border-color: ${colors.primary400};
+    color: white;
+    font-weight: 600;
+  }
+`;
+
+const categories = ['게임', '영화', '맛집탐방', '운동', '스터디', '기타'];
+
+interface MapFiltersProps {
+  selectedCategories: string[];
+  onCategoryClick: (category: string) => void;
+}
+
+export const MapFilters = ({ selectedCategories, onCategoryClick }: MapFiltersProps) => {
+  return (
+    <FiltersContainer>
+      {categories.map((category) => (
+        <FilterButton
+          key={category}
+          className={selectedCategories.includes(category) ? 'selected' : ''}
+          onClick={() => onCategoryClick(category)}
+        >
+          {category}
+        </FilterButton>
+      ))}
+    </FiltersContainer>
+  );
+};

--- a/src/components/home_page/MeetingDetailModal.tsx
+++ b/src/components/home_page/MeetingDetailModal.tsx
@@ -19,7 +19,7 @@ import {
 interface MeetingDetailModalProps {
   meeting: Meeting;
   onClose: () => void;
-  isOpen: boolean;
+  isOpen?: boolean;
 }
 
 export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailModalProps) => {

--- a/src/components/home_page/MeetingIcon.tsx
+++ b/src/components/home_page/MeetingIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import StudyIcon from '@/assets/meeting_icons/study.svg?react';
 import SportsIcon from '@/assets/meeting_icons/sport.svg?react';
 import GameIcon from '@/assets/meeting_icons/game.svg?react';

--- a/src/components/home_page/RadiusFilter.tsx
+++ b/src/components/home_page/RadiusFilter.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+import { colors } from '@/style/themes';
+
+const FilterContainer = styled.div`
+  position: absolute;
+  top: 120px;
+  right: 16px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 8px;
+  border-radius: 28px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+`;
+
+const FilterButton = styled.button`
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 1px solid ${colors.secondary200};
+  background-color: white;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: ${colors.secondary500};
+  transition: all 0.2s ease-in-out;
+
+  &.selected {
+    background-color: ${colors.primary400};
+    border-color: ${colors.primary400};
+    color: white;
+    font-weight: 700;
+  }
+`;
+
+const radii = ['1km', '3km', '5km'];
+
+interface RadiusFilterProps {
+  selectedRadius: string | null;
+  onRadiusClick: (radius: string) => void;
+}
+
+export const RadiusFilter = ({ selectedRadius, onRadiusClick }: RadiusFilterProps) => {
+  return (
+    <FilterContainer>
+      {radii.map((radius) => (
+        <FilterButton
+          key={radius}
+          className={selectedRadius === radius ? 'selected' : ''}
+          onClick={() => onRadiusClick(radius)}
+        >
+          {radius}
+        </FilterButton>
+      ))}
+    </FilterContainer>
+  );
+};

--- a/src/components/meeting_room_page/ChatInput.tsx
+++ b/src/components/meeting_room_page/ChatInput.tsx
@@ -4,9 +4,12 @@ import React from 'react';
 import type { ChatMessage } from '@/types/meeting_room_page/chatMessage';
 import type { SetState } from '@/types/meeting_room_page/chatMessage';
 
+type MessageType = 'TEXT' | 'IMAGE' | 'SYSTEM';
+
 interface ChatInputProps {
   chatMessages: ChatMessage[];
   setChatMessages: SetState<ChatMessage[]>;
+  sendMessage: (type: MessageType, message: string) => void;
 }
 
 const Container = styled.div`
@@ -56,10 +59,10 @@ const HelperText = styled.div`
   margin-top: 0.3rem;
 `;
 
-export const ChatInput = ({ chatMessages, setChatMessages }: ChatInputProps) => {
+export const ChatInput = ({ chatMessages, setChatMessages, sendMessage }: ChatInputProps) => {
   const [text, setText] = React.useState('');
 
-  const sendMessage = () => {
+  const handleClick = () => {
     const trimmedText = text.trim();
 
     if (!trimmedText) {
@@ -74,6 +77,7 @@ export const ChatInput = ({ chatMessages, setChatMessages }: ChatInputProps) => 
       time: new Date(),
     };
 
+    sendMessage('TEXT', trimmedText);
     setChatMessages([...chatMessages, newMessage]);
     setText('');
   };
@@ -87,11 +91,11 @@ export const ChatInput = ({ chatMessages, setChatMessages }: ChatInputProps) => 
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
-            sendMessage();
+            handleClick();
           }
         }}
       />
-      <Button onClick={sendMessage}>
+      <Button onClick={handleClick}>
         <Send style={{ position: 'absolute', top: '0.75rem', right: '3rem' }} />
       </Button>
       <HelperText>Enter: 전송, Shift + Enter: 줄바꿈</HelperText>

--- a/src/components/meeting_room_page/Message.tsx
+++ b/src/components/meeting_room_page/Message.tsx
@@ -10,7 +10,6 @@ const Container = styled.div<{ isMine: boolean }>`
   flex-direction: row;
   width: 100%;
   height: auto;
-  min-height: ${({ isMine }) => (isMine ? '3rem' : '4rem')};
   justify-content: flex-start;
   align-items: flex-start;
   margin-bottom: 0.4rem;
@@ -42,7 +41,7 @@ const Content = styled.div<{ isMine: boolean }>`
   display: flex;
   width: auto;
   min-width: 3rem;
-  max-width: 15rem;
+  max-width: 60%;
   height: auto;
   min-height: 1.5rem;
   line-height: 1.25rem;

--- a/src/components/onboarding/OnboardingStep1.tsx
+++ b/src/components/onboarding/OnboardingStep1.tsx
@@ -19,20 +19,39 @@ const OnboardingStep1 = ({ data, onNext }: OnboardingStepProps) => {
   });
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
+  const validateNickname = (nickname: string) => {
+    const trimmed = nickname.trim();
+    
+    if (!trimmed) {
+      return '닉네임을 입력해주세요';
+    }
+    
+    if (trimmed.length < 2 && trimmed.length > 20) {
+      return '닉네임은 2자 이상 20자 이하여야 합니다';
+    }
+    
+
+    return null; 
+  };
+
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
-    // 에러 메시지 초기화
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: '' }));
+    
+    if (field === 'nickname') {
+      const error = validateNickname(value);
+      setErrors((prev) => ({ ...prev, [field]: error || '' }));
     }
   };
 
   const handleNext = () => {
-    if (!formData.nickname.trim()) {
-      setErrors({ nickname: '닉네임을 입력해주세요' });
+    const nicknameError = validateNickname(formData.nickname);
+    
+    if (nicknameError) {
+      setErrors({ nickname: nicknameError });
       return;
     }
-    onNext({ nickname: formData.nickname });
+    
+    onNext({ nickname: formData.nickname.trim() });
   };
 
   return (
@@ -47,11 +66,22 @@ const OnboardingStep1 = ({ data, onNext }: OnboardingStepProps) => {
         <FormField>
           <FormInput
             type="text"
-            placeholder="닉네임"
+            placeholder="닉네임 (2~20자)"
             value={formData.nickname}
             onChange={(e) => handleInputChange('nickname', e.target.value)}
+            maxLength={20}
           />
           {errors.nickname && <ErrorMessage>{errors.nickname}</ErrorMessage>}
+          {!errors.nickname && formData.nickname && (
+            <div style={{ 
+              fontSize: '0.75rem', 
+              color: '#666', 
+              marginTop: '4px',
+              textAlign: 'right'
+            }}>
+              {formData.nickname.trim().length}/20자
+            </div>
+          )}
         </FormField>
       </FormSection>
 

--- a/src/components/onboarding/OnboardingStep3.tsx
+++ b/src/components/onboarding/OnboardingStep3.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { OnboardingStepProps } from '@/types/onboarding';
 import {
   FormSection,
@@ -22,7 +22,7 @@ import backArrow from '@/assets/onoboarding_page/chevron-left.svg';
 import searchIcon from '@/assets/onoboarding_page/search.svg';
 import { Spacer } from '@/style/CommonStyle';
 
-const OnboardingStep3 = ({ data, onNext, onPrev }: OnboardingStepProps) => {
+const OnboardingStep3 = ({ onNext, onPrev }: OnboardingStepProps) => {
   const [sido, setSido] = useState('');
   const [sigungu, setSigungu] = useState('');
   const [sidoSuggestions, setSidoSuggestions] = useState<string[]>([]);
@@ -31,16 +31,115 @@ const OnboardingStep3 = ({ data, onNext, onPrev }: OnboardingStepProps) => {
   const [showSigunguSuggestions, setShowSigunguSuggestions] = useState(false);
 
   // 더미 위치 데이터
-  const sidoList = ['서울특별시', '부산광역시', '대구광역시', '인천광역시', '광주광역시', '대전광역시', '울산광역시', '세종특별자치시', '경기도', '강원도', '충청북도', '충청남도', '전라북도', '전라남도', '경상북도', '경상남도', '제주특별자치도'];
-  
-  const sigunguData: { [key: string]: string[] } = {
-    '서울특별시': ['강남구', '강동구', '강북구', '강서구', '관악구', '광진구', '구로구', '금천구', '노원구', '도봉구', '동대문구', '동작구', '마포구', '서대문구', '서초구', '성동구', '성북구', '송파구', '양천구', '영등포구', '용산구', '은평구', '종로구', '중구', '중랑구'],
-    '부산광역시': ['중구', '서구', '동구', '영도구', '부산진구', '동래구', '남구', '북구', '해운대구', '사하구', '금정구', '강서구', '연제구', '수영구', '사상구', '기장군'],
-    '대구광역시': ['중구', '동구', '서구', '남구', '북구', '수성구', '달서구', '달성군'],
-    '인천광역시': ['중구', '동구', '미추홀구', '연수구', '남동구', '부평구', '계양구', '서구', '강화군', '옹진군'],
-    '경기도': ['수원시', '성남시', '의정부시', '안양시', '부천시', '광명시', '평택시', '과천시', '오산시', '시흥시', '군포시', '의왕시', '하남시', '용인시', '파주시', '이천시', '안성시', '김포시', '화성시', '광주시', '여주시', '양평군', '고양시', '의정부시', '동두천시', '가평군', '연천군']
-  };
+  const sidoList = [
+    '서울특별시',
+    '부산광역시',
+    '대구광역시',
+    '인천광역시',
+    '광주광역시',
+    '대전광역시',
+    '울산광역시',
+    '세종특별자치시',
+    '경기도',
+    '강원도',
+    '충청북도',
+    '충청남도',
+    '전라북도',
+    '전라남도',
+    '경상북도',
+    '경상남도',
+    '제주특별자치도',
+  ];
 
+  const sigunguData: { [key: string]: string[] } = {
+    서울특별시: [
+      '강남구',
+      '강동구',
+      '강북구',
+      '강서구',
+      '관악구',
+      '광진구',
+      '구로구',
+      '금천구',
+      '노원구',
+      '도봉구',
+      '동대문구',
+      '동작구',
+      '마포구',
+      '서대문구',
+      '서초구',
+      '성동구',
+      '성북구',
+      '송파구',
+      '양천구',
+      '영등포구',
+      '용산구',
+      '은평구',
+      '종로구',
+      '중구',
+      '중랑구',
+    ],
+    부산광역시: [
+      '중구',
+      '서구',
+      '동구',
+      '영도구',
+      '부산진구',
+      '동래구',
+      '남구',
+      '북구',
+      '해운대구',
+      '사하구',
+      '금정구',
+      '강서구',
+      '연제구',
+      '수영구',
+      '사상구',
+      '기장군',
+    ],
+    대구광역시: ['중구', '동구', '서구', '남구', '북구', '수성구', '달서구', '달성군'],
+    인천광역시: [
+      '중구',
+      '동구',
+      '미추홀구',
+      '연수구',
+      '남동구',
+      '부평구',
+      '계양구',
+      '서구',
+      '강화군',
+      '옹진군',
+    ],
+    경기도: [
+      '수원시',
+      '성남시',
+      '의정부시',
+      '안양시',
+      '부천시',
+      '광명시',
+      '평택시',
+      '과천시',
+      '오산시',
+      '시흥시',
+      '군포시',
+      '의왕시',
+      '하남시',
+      '용인시',
+      '파주시',
+      '이천시',
+      '안성시',
+      '김포시',
+      '화성시',
+      '광주시',
+      '여주시',
+      '양평군',
+      '고양시',
+      '의정부시',
+      '동두천시',
+      '가평군',
+      '연천군',
+    ],
+  };
 
   const handleSidoChange = (value: string) => {
     setSido(value);
@@ -87,11 +186,11 @@ const OnboardingStep3 = ({ data, onNext, onPrev }: OnboardingStepProps) => {
 
   const handleNext = () => {
     if (sido.trim() && sigungu.trim()) {
-      onNext({ 
+      onNext({
         baseLocation: {
           sidoName: sido,
-          sigunguName: sigungu
-        }
+          sigunguName: sigungu,
+        },
       });
     } else {
       alert('시/도와 시/군/구를 모두 선택해주세요');

--- a/src/components/onboarding/OnboardingStep3.tsx
+++ b/src/components/onboarding/OnboardingStep3.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { OnboardingStepProps } from '@/types/onboarding';
 import {
   FormSection,
@@ -23,38 +23,78 @@ import searchIcon from '@/assets/onoboarding_page/search.svg';
 import { Spacer } from '@/style/CommonStyle';
 
 const OnboardingStep3 = ({ data, onNext, onPrev }: OnboardingStepProps) => {
-  const [location, setLocation] = useState(data.baseLocation || '');
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [sido, setSido] = useState('');
+  const [sigungu, setSigungu] = useState('');
+  const [sidoSuggestions, setSidoSuggestions] = useState<string[]>([]);
+  const [sigunguSuggestions, setSigunguSuggestions] = useState<string[]>([]);
+  const [showSidoSuggestions, setShowSidoSuggestions] = useState(false);
+  const [showSigunguSuggestions, setShowSigunguSuggestions] = useState(false);
 
-  // 더미 위치 데이터 (실제로는 API에서 가져와야 함)
-  const dummyLocations = ['서울특별시', '세명시', '인천광역시', '부산광역시', '대구광역시'];
+  // 더미 위치 데이터
+  const sidoList = ['서울특별시', '부산광역시', '대구광역시', '인천광역시', '광주광역시', '대전광역시', '울산광역시', '세종특별자치시', '경기도', '강원도', '충청북도', '충청남도', '전라북도', '전라남도', '경상북도', '경상남도', '제주특별자치도'];
+  
+  const sigunguData: { [key: string]: string[] } = {
+    '서울특별시': ['강남구', '강동구', '강북구', '강서구', '관악구', '광진구', '구로구', '금천구', '노원구', '도봉구', '동대문구', '동작구', '마포구', '서대문구', '서초구', '성동구', '성북구', '송파구', '양천구', '영등포구', '용산구', '은평구', '종로구', '중구', '중랑구'],
+    '부산광역시': ['중구', '서구', '동구', '영도구', '부산진구', '동래구', '남구', '북구', '해운대구', '사하구', '금정구', '강서구', '연제구', '수영구', '사상구', '기장군'],
+    '대구광역시': ['중구', '동구', '서구', '남구', '북구', '수성구', '달서구', '달성군'],
+    '인천광역시': ['중구', '동구', '미추홀구', '연수구', '남동구', '부평구', '계양구', '서구', '강화군', '옹진군'],
+    '경기도': ['수원시', '성남시', '의정부시', '안양시', '부천시', '광명시', '평택시', '과천시', '오산시', '시흥시', '군포시', '의왕시', '하남시', '용인시', '파주시', '이천시', '안성시', '김포시', '화성시', '광주시', '여주시', '양평군', '고양시', '의정부시', '동두천시', '가평군', '연천군']
+  };
 
-  const handleLocationChange = (value: string) => {
-    setLocation(value);
+
+  const handleSidoChange = (value: string) => {
+    setSido(value);
+    setSigungu(''); // 시/도 변경 시 시/군/구 초기화
 
     if (value.trim()) {
-      const filtered = dummyLocations.filter((loc) =>
-        loc.toLowerCase().includes(value.toLowerCase()),
+      const filtered = sidoList.filter((sidoName) =>
+        sidoName.toLowerCase().includes(value.toLowerCase()),
       );
-      setSuggestions(filtered);
-      setShowSuggestions(true);
+      setSidoSuggestions(filtered);
+      setShowSidoSuggestions(true);
     } else {
-      setSuggestions([]);
-      setShowSuggestions(false);
+      setSidoSuggestions([]);
+      setShowSidoSuggestions(false);
     }
   };
 
-  const handleLocationSelect = (selectedLocation: string) => {
-    setLocation(selectedLocation);
-    setShowSuggestions(false);
+  const handleSigunguChange = (value: string) => {
+    setSigungu(value);
+
+    if (value.trim() && sido) {
+      const sigunguList = sigunguData[sido] || [];
+      const filtered = sigunguList.filter((sigunguName) =>
+        sigunguName.toLowerCase().includes(value.toLowerCase()),
+      );
+      setSigunguSuggestions(filtered);
+      setShowSigunguSuggestions(true);
+    } else {
+      setSigunguSuggestions([]);
+      setShowSigunguSuggestions(false);
+    }
+  };
+
+  const handleSidoSelect = (selectedSido: string) => {
+    setSido(selectedSido);
+    setSigungu('');
+    setShowSidoSuggestions(false);
+  };
+
+  const handleSigunguSelect = (selectedSigungu: string) => {
+    setSigungu(selectedSigungu);
+    setShowSigunguSuggestions(false);
   };
 
   const handleNext = () => {
-    if (location.trim()) {
-      onNext({ baseLocation: location });
+    if (sido.trim() && sigungu.trim()) {
+      onNext({ 
+        baseLocation: {
+          sidoName: sido,
+          sigunguName: sigungu
+        }
+      });
     } else {
-      alert('위치를 선택해주세요');
+      alert('시/도와 시/군/구를 모두 선택해주세요');
     }
   };
 
@@ -74,19 +114,45 @@ const OnboardingStep3 = ({ data, onNext, onPrev }: OnboardingStepProps) => {
           <SearchInputContainer>
             <FormInput
               type="text"
-              placeholder="예: 부산"
-              value={location}
+              placeholder="시/도 선택 (예: 부산광역시)"
+              value={sido}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                handleLocationChange(e.target.value)
+                handleSidoChange(e.target.value)
               }
-              onFocus={() => setShowSuggestions(true)}
-              onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
+              onFocus={() => setShowSidoSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSidoSuggestions(false), 100)}
             />
             <SearchIcon src={searchIcon} alt="search" />
-            {showSuggestions && suggestions.length > 0 && (
+            {showSidoSuggestions && sidoSuggestions.length > 0 && (
               <SuggestionList>
-                {suggestions.map((suggestion, index) => (
-                  <SuggestionItem key={index} onClick={() => handleLocationSelect(suggestion)}>
+                {sidoSuggestions.map((suggestion, index) => (
+                  <SuggestionItem key={index} onClick={() => handleSidoSelect(suggestion)}>
+                    {suggestion}
+                  </SuggestionItem>
+                ))}
+              </SuggestionList>
+            )}
+          </SearchInputContainer>
+        </FormField>
+
+        <FormField>
+          <SearchInputContainer>
+            <FormInput
+              type="text"
+              placeholder="시/군/구 선택 (예: 금정구)"
+              value={sigungu}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleSigunguChange(e.target.value)
+              }
+              onFocus={() => setShowSigunguSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSigunguSuggestions(false), 100)}
+              disabled={!sido.trim()}
+            />
+            <SearchIcon src={searchIcon} alt="search" />
+            {showSigunguSuggestions && sigunguSuggestions.length > 0 && (
+              <SuggestionList>
+                {sigunguSuggestions.map((suggestion, index) => (
+                  <SuggestionItem key={index} onClick={() => handleSigunguSelect(suggestion)}>
                     {suggestion}
                   </SuggestionItem>
                 ))}

--- a/src/components/room_create_page.tsx/HobbySelector.tsx
+++ b/src/components/room_create_page.tsx/HobbySelector.tsx
@@ -1,32 +1,7 @@
 import React from 'react';
 import { StyledSelect } from './StyledComponents';
 
-const hobbyData = [
-  {
-    category: '운동',
-    hobbies: ['풋살', '축구', '농구', '배드민턴', '볼링', '테니스', '헬스', '러닝'],
-  },
-  {
-    category: '스터디',
-    hobbies: ['코딩', '외국어', '독서', '자격증', '면접 준비'],
-  },
-  {
-    category: '게임',
-    hobbies: ['보드게임', 'PC게임', '콘솔게임', '모바일게임'],
-  },
-  {
-    category: '문화/예술',
-    hobbies: ['영화', '전시회', '뮤지컬', '콘서트', '공연 관람'],
-  },
-  {
-    category: '맛집탐방',
-    hobbies: ['맛집투어', '카페투어', '빵집투어', '요리/베이킹'],
-  },
-  {
-    category: '기타',
-    hobbies: ['산책', '여행', '봉사활동', '반려동물'],
-  },
-];
+const hobbyCategories = ['운동', '스터디', '게임', '문화/예술', '맛집탐방', '기타'];
 
 interface HobbySelectorProps {
   value: string;
@@ -35,15 +10,14 @@ interface HobbySelectorProps {
 
 export const HobbySelector = ({ value, onChange }: HobbySelectorProps) => {
   return (
-    <StyledSelect name="hobby" value={value} onChange={onChange}>
-      {hobbyData.map((group) => (
-        <optgroup key={group.category} label={group.category}>
-          {group.hobbies.map((hobby) => (
-            <option key={hobby} value={hobby}>
-              {hobby}
-            </option>
-          ))}
-        </optgroup>
+    <StyledSelect name="category" value={value} onChange={onChange}>
+      <option value="" disabled>
+        취미를 선택해주세요
+      </option>
+      {hobbyCategories.map((category) => (
+        <option key={category} value={category}>
+          {category}
+        </option>
       ))}
     </StyledSelect>
   );

--- a/src/components/room_create_page.tsx/HobbySelector.tsx
+++ b/src/components/room_create_page.tsx/HobbySelector.tsx
@@ -1,23 +1,30 @@
 import React from 'react';
-import { StyledSelect } from './StyledComponents'; // 스타일 재사용
+import { StyledSelect } from './StyledComponents';
 
-// 취미 데이터를 카테고리별로 그룹화
 const hobbyData = [
   {
-    category: '스포츠',
-    hobbies: ['풋살', '축구', '농구', '배드민턴', '볼링', '테니스'],
+    category: '운동',
+    hobbies: ['풋살', '축구', '농구', '배드민턴', '볼링', '테니스', '헬스', '러닝'],
   },
   {
-    category: '관람/문화',
-    hobbies: ['영화', '전시회', '뮤지컬', '콘서트', '독서'],
+    category: '스터디',
+    hobbies: ['코딩', '외국어', '독서', '자격증', '면접 준비'],
   },
   {
     category: '게임',
-    hobbies: ['보드게임', 'PC게임', '콘솔게임'],
+    hobbies: ['보드게임', 'PC게임', '콘솔게임', '모바일게임'],
+  },
+  {
+    category: '문화/예술',
+    hobbies: ['영화', '전시회', '뮤지컬', '콘서트', '공연 관람'],
+  },
+  {
+    category: '맛집탐방',
+    hobbies: ['맛집투어', '카페투어', '빵집투어', '요리/베이킹'],
   },
   {
     category: '기타',
-    hobbies: ['스터디', '코딩', '맛집탐방'],
+    hobbies: ['산책', '여행', '봉사활동', '반려동물'],
   },
 ];
 

--- a/src/components/room_create_page.tsx/TimePicker.tsx
+++ b/src/components/room_create_page.tsx/TimePicker.tsx
@@ -1,6 +1,30 @@
-import React from 'react';
 import styled from 'styled-components';
-import { StyledInput, Grid } from './StyledComponents';
+import { StyledSelect } from './StyledComponents';
+
+const TimePickerContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+`;
+
+const TimeInputWrapper = styled.div`
+  display: grid;
+  /* 날짜, 시간, 분 필드의 비율을 조정합니다. */
+  grid-template-columns: 2.5fr 1.5fr 1.5fr;
+  gap: 8px;
+  align-items: center;
+`;
+
+const DateInput = styled.input`
+  padding: 11px;
+  font-size: 0.9rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background-color: #f9fafb;
+  color: #333;
+  box-sizing: border-box;
+  width: 100%;
+`;
 
 const ErrorMessage = styled.p`
   color: #ef4444;
@@ -11,18 +35,82 @@ const ErrorMessage = styled.p`
 interface TimePickerProps {
   startTime: string;
   endTime: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: { target: { name: string; value: string } }) => void;
   error?: string | null;
 }
 
+const hourOptions = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'));
+const minuteOptions = ['00', '30'];
+
+const CustomTimeInput = ({
+  name,
+  value,
+  onChange,
+}: {
+  name: 'startTime' | 'endTime';
+  value: string;
+  onChange: (e: { target: { name: string; value: string } }) => void;
+}) => {
+  const [datePart, timePart] = value.split('T');
+  const [hourPart, minutePart] = timePart?.split(':') || ['', ''];
+
+  const handleValueChange = (part: 'date' | 'hour' | 'minute', newValue: string) => {
+    let newDate = datePart || '';
+    let newHour = hourPart || '00';
+    let newMinute = minutePart || '00';
+
+    if (part === 'date') newDate = newValue;
+    if (part === 'hour') newHour = newValue;
+    if (part === 'minute') newMinute = newValue;
+
+    if (!newDate && part !== 'date') {
+      alert('날짜를 먼저 선택해주세요.');
+      return;
+    }
+
+    const combinedValue = `${newDate}T${newHour}:${newMinute}`;
+    onChange({ target: { name, value: combinedValue } });
+  };
+
+  return (
+    <TimeInputWrapper>
+      <DateInput
+        type="date"
+        value={datePart || ''}
+        onChange={(e) => handleValueChange('date', e.target.value)}
+      />
+      <StyledSelect
+        value={hourPart || '00'}
+        onChange={(e) => handleValueChange('hour', e.target.value)}
+      >
+        {hourOptions.map((h) => (
+          <option key={h} value={h}>
+            {h}시
+          </option>
+        ))}
+      </StyledSelect>
+      <StyledSelect
+        value={minutePart || '00'}
+        onChange={(e) => handleValueChange('minute', e.target.value)}
+      >
+        {minuteOptions.map((m) => (
+          <option key={m} value={m}>
+            {m}분
+          </option>
+        ))}
+      </StyledSelect>
+    </TimeInputWrapper>
+  );
+};
+
 export const TimePicker = ({ startTime, endTime, onChange, error }: TimePickerProps) => {
   return (
-    <>
-      <Grid>
-        <StyledInput type="datetime-local" name="startTime" value={startTime} onChange={onChange} />
-        <StyledInput type="datetime-local" name="endTime" value={endTime} onChange={onChange} />
-      </Grid>
+    <TimePickerContainer>
+      <label>시작 시간</label>
+      <CustomTimeInput name="startTime" value={startTime} onChange={onChange} />
+      <label>종료 시간</label>
+      <CustomTimeInput name="endTime" value={endTime} onChange={onChange} />
       {error && <ErrorMessage>{error}</ErrorMessage>}
-    </>
+    </TimePickerContainer>
   );
 };

--- a/src/components/room_create_page.tsx/useCreateForm.ts
+++ b/src/components/room_create_page.tsx/useCreateForm.ts
@@ -9,11 +9,11 @@ export interface LocationData {
 
 export interface FormState {
   name: string;
-  hobby: string;
+  category: string;
   startTime: string;
   endTime: string;
   capacity: string;
-  minTemp: string;
+  scoreLimit: string;
   location: LocationData | null;
 }
 
@@ -26,6 +26,10 @@ const validateTime = (startTime: string, endTime: string): string | null => {
   const start = new Date(startTime);
   const end = new Date(endTime);
   const in24Hours = new Date(now.getTime() + ONE_DAY_IN_MILLISECONDS);
+
+  if (start.getMinutes() % 30 !== 0 || end.getMinutes() % 30 !== 0) {
+    return '시간은 30분 단위로 설정해야 합니다.';
+  }
 
   if (start <= now) return '시작 시간은 현재 시간 이후여야 합니다.';
   if (start > in24Hours) return '모임은 24시간 이내에 시작해야 합니다.';
@@ -43,11 +47,11 @@ export const useCreateForm = () => {
   const [formState, setFormState] = useState<FormState>(() => {
     const initialState = location.state?.formValues || {
       name: '',
-      hobby: '풋살',
+      category: '',
       startTime: '',
       endTime: '',
       capacity: '',
-      minTemp: '',
+      scoreLimit: '',
       location: null,
     };
 
@@ -67,7 +71,11 @@ export const useCreateForm = () => {
     [formState.startTime, formState.endTime],
   );
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const handleChange = (
+    e:
+      | React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+      | { target: { name: string; value: string } },
+  ) => {
     const { name, value } = e.target;
     setFormState((prevState) => ({
       ...prevState,
@@ -78,8 +86,9 @@ export const useCreateForm = () => {
   const isFormValid = useMemo(() => {
     return (
       formState.name.trim() !== '' &&
+      formState.category.trim() !== '' &&
       formState.capacity.trim() !== '' &&
-      formState.minTemp.trim() !== '' &&
+      formState.scoreLimit.trim() !== '' &&
       formState.startTime !== '' &&
       formState.endTime !== '' &&
       !timeError &&

--- a/src/components/search_page/SearchFilters.tsx
+++ b/src/components/search_page/SearchFilters.tsx
@@ -45,7 +45,7 @@ const FilterButton = styled.button`
   }
 `;
 
-const categories = ['운동', '스터디', '취미', '맛집탐방'];
+const categories = ['게임', '영화', '맛집탐방', '운동', '스터디', '기타'];
 const radii = ['1km', '3km', '5km'];
 
 interface SearchFiltersProps {

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,0 +1,27 @@
+import { useState, Children, isValidElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
+interface StepProps<T extends string[]> {
+  name: T[number];
+  children: ReactNode;
+}
+
+export const useFunnel = <T extends string[]>(steps: T) => {
+  const [step, setStep] = useState<T[number]>(steps[0]);
+
+  const Step = ({ children }: StepProps<T>) => <>{children}</>;
+
+  const Funnel = ({ children }: { children: ReactElement<StepProps<T>>[] }) => {
+    const targetStep = Children.toArray(children).find((child) => {
+      if (isValidElement<StepProps<T>>(child)) {
+        return child.props.name === step;
+      }
+      return false;
+    });
+
+    return <>{targetStep}</>;
+  };
+
+  return [Funnel, Step, setStep, step] as const;
+};
+

--- a/src/pages/LocationPicker.tsx
+++ b/src/pages/LocationPicker.tsx
@@ -67,89 +67,107 @@ const ConfirmButton = styled.button`
 
 const LocationPicker = () => {
   const mapRef = useRef<HTMLDivElement>(null);
+  const markerRef = useRef<any>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const { formValues, hashtags, currentLocation } = location.state || {};
 
+  const [map, setMap] = useState<any>(null);
+  const [geocoder, setGeocoder] = useState<any>(null);
   const [selectedLocation, setSelectedLocation] = useState<LocationInfo | null>(
     currentLocation || null,
   );
-  const markerRef = useRef<any>(null);
 
   useEffect(() => {
     const APP_KEY = (import.meta.env.VITE_KAKAO_MAP_KEY as string) || apikey?.kakaoMapKey;
+    const scriptId = 'kakao-map-script';
 
-    const loadMap = () => {
+    const initializeMap = () => {
       window.kakao.maps.load(() => {
         if (!mapRef.current) return;
 
-        const initialLocation = currentLocation;
-        const center = initialLocation
-          ? new window.kakao.maps.LatLng(initialLocation.lat, initialLocation.lng)
-          : new window.kakao.maps.LatLng(35.179554, 129.075642);
+        const center = new window.kakao.maps.LatLng(35.179554, 129.075642);
+        const options = { center, level: 3 };
+        const mapInstance = new window.kakao.maps.Map(mapRef.current, options);
+        const geocoderInstance = new window.kakao.maps.services.Geocoder();
 
-        const options = {
-          center: center,
-          level: 3,
-        };
-        const map = new window.kakao.maps.Map(mapRef.current, options);
-        const geocoder = new window.kakao.maps.services.Geocoder();
-
-        if (initialLocation) {
-          const initialMarker = new window.kakao.maps.Marker({ position: center });
-          initialMarker.setMap(map);
-          markerRef.current = initialMarker;
-        }
-
-        window.kakao.maps.event.addListener(map, 'click', (mouseEvent: any) => {
-          const latlng = mouseEvent.latLng;
-
-          if (markerRef.current) {
-            markerRef.current.setPosition(latlng);
-          } else {
-            const newMarker = new window.kakao.maps.Marker({ position: latlng });
-            newMarker.setMap(map);
-            markerRef.current = newMarker;
-          }
-
-          geocoder.coord2Address(latlng.getLng(), latlng.getLat(), (result: any, status: any) => {
-            if (status === window.kakao.maps.services.Status.OK) {
-              const roadAddress =
-                result[0]?.road_address?.address_name || result[0]?.address?.address_name;
-              setSelectedLocation({
-                name: roadAddress,
-                lat: latlng.getLat(),
-                lng: latlng.getLng(),
-              });
-            }
-          });
-        });
+        setMap(mapInstance);
+        setGeocoder(geocoderInstance);
       });
     };
 
-    if (window.kakao && window.kakao.maps) {
-      loadMap();
+    let script = document.getElementById(scriptId) as HTMLScriptElement | null;
+
+    if (!script) {
+      script = document.createElement('script');
+      script.id = scriptId;
+      script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${APP_KEY}&libraries=services&autoload=false`;
+      script.async = true;
+      document.head.appendChild(script);
+
+      script.onload = () => {
+        script!.dataset.loaded = 'true';
+        initializeMap();
+      };
+    } else if (script.dataset.loaded) {
+      // 스크립트는 있지만, 로딩이 완료된 경우
+      initializeMap();
     } else {
-      const scriptId = 'kakao-map-script';
-      const existingScript = document.getElementById(scriptId) as HTMLScriptElement | null;
-
-      if (!existingScript) {
-        const script = document.createElement('script');
-        script.id = scriptId;
-        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${APP_KEY}&libraries=services&autoload=false`;
-        script.async = true;
-        document.head.appendChild(script);
-
-        script.onload = () => {
-          loadMap();
-        };
-      } else {
-        existingScript.onload = () => {
-          loadMap();
-        };
-      }
+      // 스크립트는 있지만, 아직 로딩 중인 경우
+      const handleLoad = () => initializeMap();
+      script.addEventListener('load', handleLoad);
+      return () => {
+        script?.removeEventListener('load', handleLoad);
+      };
     }
-  }, [currentLocation]);
+  }, []);
+
+  useEffect(() => {
+    if (!map || !geocoder) return;
+
+    if (currentLocation && !selectedLocation) {
+      const initialPosition = new window.kakao.maps.LatLng(
+        currentLocation.lat,
+        currentLocation.lng,
+      );
+      map.setCenter(initialPosition);
+      const marker = new window.kakao.maps.Marker({ position: initialPosition });
+      marker.setMap(map);
+      markerRef.current = marker;
+    }
+
+    const handleClick = (mouseEvent: any) => {
+      const latlng = mouseEvent.latLng;
+
+      if (markerRef.current) {
+        markerRef.current.setPosition(latlng);
+      } else {
+        const newMarker = new window.kakao.maps.Marker({ position: latlng });
+        newMarker.setMap(map);
+        markerRef.current = newMarker;
+      }
+
+      geocoder.coord2Address(latlng.getLng(), latlng.getLat(), (result: any, status: any) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          const roadAddress =
+            result[0]?.road_address?.address_name || result[0]?.address?.address_name;
+          setSelectedLocation({
+            name: roadAddress,
+            lat: latlng.getLat(),
+            lng: latlng.getLng(),
+          });
+        }
+      });
+    };
+
+    window.kakao.maps.event.addListener(map, 'click', handleClick);
+
+    return () => {
+      if (window.kakao && window.kakao.maps && window.kakao.maps.event && map) {
+        window.kakao.maps.event.removeListener(map, 'click', handleClick);
+      }
+    };
+  }, [map, geocoder, currentLocation]);
 
   const handleConfirm = () => {
     if (selectedLocation) {
@@ -163,6 +181,7 @@ const LocationPicker = () => {
       });
     }
   };
+
   const handleBack = () => {
     navigate('/create-room', {
       state: {
@@ -179,7 +198,10 @@ const LocationPicker = () => {
       <GlobalStyle />
       <KakaoMapCssFix />
       <PageContainer>
-        <CommonHeader title="지도에서 위치 선택" onBackButtonClick={handleBack} />
+        <CommonHeader
+          title="지도에서 위치 선택(위치선택이 되지 않을 시 새로고침)"
+          onBackButtonClick={handleBack}
+        />
         <MapContainer ref={mapRef} />
         <ConfirmButton onClick={handleConfirm} disabled={!selectedLocation}>
           {selectedLocation ? `'${selectedLocation.name}' 확정` : '지도를 클릭하여 위치 선택'}

--- a/src/pages/MeetingRoom.tsx
+++ b/src/pages/MeetingRoom.tsx
@@ -1,34 +1,63 @@
+import { getMyJoinedMeetup, joinMeetUp } from '@/api/services/meeting_room.service';
 import { ChatBox } from '@/components/meeting_room_page/ChatBox';
 import { ChatInput } from '@/components/meeting_room_page/ChatInput';
 import { Header } from '@/components/meeting_room_page/Header';
 import { mockMessages } from '@/components/meeting_room_page/mockData';
 import { ParticipantList } from '@/components/meeting_room_page/ParticipantList';
-// import { useAuth } from '@/hooks/useAuth';
 import { useChat } from '@/hooks/useChat';
 import { Container } from '@/style/CommonStyle';
 import type { ChatMessage } from '@/types/meeting_room_page/chatMessage';
-import { getAccessToken } from '@/utils/tokenStorage';
 import { useEffect, useState } from 'react';
+
+const TEST_MEETUP_ID = 'db6acd92-a2ef-4383-9a57-94a48f4c6ea2';
 
 const MeetingRoom = () => {
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(mockMessages);
-  const { connect } = useChat('95ee73b5-9c1c-4224-b445-59094dc20152');
-  // const { login } = useAuth();
+  const [meetUpId, setmeetUpId] = useState<string | null>(null);
+  const { connect, myId, actorId, sendMessage, newChatMessage } = useChat(meetUpId);
 
   useEffect(() => {
-    (async () => {
-      // login({ email: 'user@test.com', password: 'testpass1212!' });
-      console.log(`Token: ${getAccessToken()}`);
-      connect();
-    })();
-  }, []);
+    console.log('myId:', myId, 'actorId:', actorId, 'newChatMessage:', newChatMessage);
+  }, [myId, actorId]);
+
+  useEffect(() => {
+    if (newChatMessage && myId !== actorId) {
+      setChatMessages((prevMessages) => [...prevMessages, newChatMessage]);
+    }
+  }, [newChatMessage]);
+
+  // 테스트용 모임 참가 로직
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const response = await getMyJoinedMeetup();
+        setmeetUpId(response.id);
+        console.log('모임 조회 성공:', response);
+      } catch (error) {
+        console.error(error);
+        try {
+          const response = await joinMeetUp(TEST_MEETUP_ID);
+          setmeetUpId(TEST_MEETUP_ID);
+          console.log('모임 참가 성공:', response);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+    };
+    if (!meetUpId) init();
+    else connect();
+  }, [meetUpId]);
 
   return (
     <Container>
       <Header />
       <ParticipantList />
       <ChatBox chatMessages={chatMessages} />
-      <ChatInput chatMessages={chatMessages} setChatMessages={setChatMessages} />
+      <ChatInput
+        chatMessages={chatMessages}
+        setChatMessages={setChatMessages}
+        sendMessage={sendMessage}
+      />
     </Container>
   );
 };

--- a/src/pages/My.styled.ts
+++ b/src/pages/My.styled.ts
@@ -15,6 +15,60 @@ export const HeaderSection = styled.div`
   clip-path: ellipse(130% 100% at 50% 0%);
 `;
 
+// 뱃지 섹션
+export const BadgeSection = styled.div`
+  margin-top: 24px;
+  padding: 0 20px;
+`;
+
+export const BadgeContainer = styled.div`
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-height: 60px;
+`;
+
+export const BadgeItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 8px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  min-width: 80px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: #f3f4f6;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export const BadgeIcon = styled.img`
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+`;
+
+export const BadgeName = styled.span`
+  font-size: 0.75rem;
+  color: #374151;
+  text-align: center;
+  font-weight: 500;
+`;
+
+export const EmptyBadgeMessage = styled.div`
+  width: 100%;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  padding: 20px 0;
+`;
+
 export const HeaderTitle = styled.h1`
   font-size: 24px;
   font-weight: 600;
@@ -101,11 +155,6 @@ export const UserGender = styled.span`
   font-weight: 500;
 `;
 
-export const UserEmail = styled.p`
-  font-size: 14px;
-  color: #7f8c8d;
-  margin: 0;
-`;
 
 export const ProfileInfoSection = styled.div`
   margin: 20px 0;

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -4,6 +4,10 @@ import { Container, ContentContanier } from '@/style/CommonStyle';
 import type { RootState } from '@/store';
 import { setMyProfile } from '@/store/slices/myProfileSlice';
 import { getMyProfile, updateProfile } from '@/api/auth';
+import { getMyBadges } from '@/api/badge';
+import { useLogin } from '@/hooks/useLogin';
+import { getProfile } from '@/utils/tokenStorage';
+import type { Badge } from '@/types/badge';
 import {
   HeaderTitle,
   ProfileImageContainer,
@@ -15,7 +19,6 @@ import {
   UserName,
   UserAge,
   UserGender,
-  UserEmail,
   ProfileInfoSection,
   ProfileInfoItem,
   InfoLabel,
@@ -40,22 +43,33 @@ import {
   ButtonGroup,
   CancelButton,
   HeaderSection,
+  BadgeSection,
+  BadgeContainer,
+  BadgeItem,
+  BadgeIcon,
+  BadgeName,
+  EmptyBadgeMessage,
 } from './My.styled';
 import BottomNav from '@/components/common/BottomNav';
 
 const My = () => {
   const dispatch = useDispatch();
   const myProfile = useSelector((state: RootState) => state.myProfile);
+  const { handleLogout } = useLogin();
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [badges, setBadges] = useState<Badge[]>([]);
   const [editData, setEditData] = useState({
-    name: myProfile.name || '',
+    nickname: myProfile.nickname || '',
     age: myProfile.age || '',
     gender: myProfile.gender || '',
     description: myProfile.description || '',
     temperature: myProfile.temperature || '',
-    baseLocation: myProfile.baseLocation || '',
+    imageUrl: myProfile.imageUrl || '',
   });
+
+  const [sido, setSido] = useState('');
+  const [sigungu, setSigungu] = useState('');
 
   // 페이지 로드 시 프로필 조회
   useEffect(() => {
@@ -64,20 +78,14 @@ const My = () => {
       try {
         const profileData = await getMyProfile();
         dispatch(setMyProfile(profileData));
-
-        localStorage.setItem('myProfile', JSON.stringify(profileData));
-        console.log('프로필 조회 성공 및 로컬 스토리지 저장:', profileData);
+        console.log('프로필 조회 성공:', profileData);
       } catch (error) {
         console.error('프로필 조회 실패:', error);
 
-        const savedProfile = localStorage.getItem('myProfile');
+        const savedProfile = getProfile();
         if (savedProfile) {
-          try {
-            const parsedProfile = JSON.parse(savedProfile);
-            dispatch(setMyProfile(parsedProfile));
-          } catch (parseError) {
-            console.error('로컬 스토리지 프로필 파싱 실패:', parseError);
-          }
+          dispatch(setMyProfile(savedProfile));
+          console.log('로컬 스토리지에서 프로필 로드:', savedProfile);
         }
       } finally {
         setIsLoading(false);
@@ -87,20 +95,62 @@ const My = () => {
     fetchProfile();
   }, [dispatch]);
 
+  // 뱃지 조회
+  useEffect(() => {
+    const fetchBadges = async () => {
+      try {
+        const data = await getMyBadges();
+        setBadges(data.content);
+        console.log('뱃지 조회 성공:', data);
+      } catch (error) {
+        console.error('뱃지 조회 실패:', error);
+      }
+    };
+
+    fetchBadges();
+  }, []);
+
   const handleCancel = () => {
     setIsEditing(false);
     setEditData({
-      name: myProfile.name || '',
+      nickname: myProfile.nickname || '',
       age: myProfile.age || '',
       gender: myProfile.gender || '',
       description: myProfile.description || '',
       temperature: myProfile.temperature || '',
-      baseLocation: myProfile.baseLocation || '',
+      imageUrl: myProfile.imageUrl || '',
     });
+    setSido('');
+    setSigungu('');
   };
 
   const handleEdit = () => {
     setIsEditing(true);
+    
+    // 기존 프로필 데이터로 editData 채우기
+    setEditData({
+      nickname: myProfile.nickname || '',
+      age: myProfile.age || '',
+      gender: myProfile.gender || '',
+      description: myProfile.description || '',
+      temperature: myProfile.temperature || '',
+      imageUrl: myProfile.imageUrl || '',
+    });
+    
+    // 기존 위치 데이터에서 시/도, 시/군/구 분리
+    if (myProfile.baseLocation) {
+      if (typeof myProfile.baseLocation === 'string') {
+        const parts = myProfile.baseLocation.split(' ');
+        if (parts.length >= 2) {
+          setSido(parts[0]);
+          setSigungu(parts[1]);
+        }
+      } else if (typeof myProfile.baseLocation === 'object' && myProfile.baseLocation !== null) {
+        const location = myProfile.baseLocation as { sidoName?: string; sigunguName?: string };
+        setSido(location.sidoName || '');
+        setSigungu(location.sigunguName || '');
+      }
+    }
   };
 
   const handleSave = async () => {
@@ -112,12 +162,14 @@ const My = () => {
         typeof editData.temperature === 'string'
           ? parseFloat(editData.temperature) || null
           : editData.temperature,
+      baseLocation: sido && sigungu ? `${sido} ${sigungu}` : null
     };
+
+    console.log('저장할 프로필 데이터:', profileData);
 
     try {
       await updateProfile(profileData);
       dispatch(setMyProfile(profileData));
-      localStorage.setItem('myProfile', JSON.stringify(profileData));
       console.log('프로필 수정 성공:', profileData);
 
       alert('프로필이 성공적으로 수정되었습니다!');
@@ -130,6 +182,18 @@ const My = () => {
 
   const handleInputChange = (field: string, value: string | number) => {
     setEditData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const result = e.target?.result as string;
+        setEditData((prev) => ({ ...prev, imageUrl: result }));
+      };
+      reader.readAsDataURL(file);
+    }
   };
 
   return (
@@ -163,11 +227,10 @@ const My = () => {
               </ProfileImageContainer>
               <UserInfo>
                 <UserBasicInfo>
-                  <UserName>{myProfile.name || '이름 없음'}</UserName>
+                  <UserName>{myProfile.nickname || '닉네임 없음'}</UserName>
                   <UserAge>{myProfile.age ? `${myProfile.age}세` : '-'}</UserAge>
                   <UserGender>{myProfile.gender || '-'}</UserGender>
                 </UserBasicInfo>
-                <UserEmail>email: {myProfile.name ? '1234567' : '1234567'}</UserEmail>
               </UserInfo>
 
               <ProfileInfoSection>
@@ -180,7 +243,13 @@ const My = () => {
 
                 <ProfileInfoItem>
                   <InfoLabel>위치</InfoLabel>
-                  <InfoValue>{myProfile.baseLocation || '-'}</InfoValue>
+                  <InfoValue>
+                    {myProfile.baseLocation ? 
+                      (typeof myProfile.baseLocation === 'string' 
+                        ? myProfile.baseLocation 
+                        : `${(myProfile.baseLocation as { sidoName: string; sigunguName: string }).sidoName} ${(myProfile.baseLocation as { sidoName: string; sigunguName: string }).sigunguName}`) 
+                      : '-'}
+                  </InfoValue>
                 </ProfileInfoItem>
 
                 <SelfIntroItem>
@@ -195,9 +264,35 @@ const My = () => {
                 </SelfIntroItem>
               </ProfileInfoSection>
 
+              {/* 뱃지 섹션 */}
+              <BadgeSection>
+                <InfoLabel style={{ marginBottom: '12px', display: 'block' }}>
+                  획득한 뱃지 ({badges.length}개)
+                </InfoLabel>
+                <BadgeContainer>
+                  {badges.length > 0 ? (
+                    badges.map((badge) => (
+                      <BadgeItem key={badge.badgeId}>
+                        <BadgeIcon src={badge.iconUrl} alt={badge.name} />
+                        <BadgeName>{badge.name}</BadgeName>
+                      </BadgeItem>
+                    ))
+                  ) : (
+                    <EmptyBadgeMessage>
+                      아직 획득한 뱃지가 없습니다
+                    </EmptyBadgeMessage>
+                  )}
+                </BadgeContainer>
+              </BadgeSection>
+
               <ActionButtons>
                 <SaveButton onClick={handleEdit}>편집</SaveButton>
               </ActionButtons>
+              
+              <ActionButtons style={{ marginTop: '16px' }}>
+                <CancelButton onClick={handleLogout}>로그아웃</CancelButton>
+              </ActionButtons>
+              
               <BottomNav />
             </MainContentCard>
 
@@ -211,12 +306,67 @@ const My = () => {
                   </ModalHeader>
                   <ModalBody>
                     <FormField>
-                      <FormLabel>이름</FormLabel>
+                      <FormLabel>프로필 이미지</FormLabel>
+                      <div
+                        onClick={() => document.getElementById('edit-profile-image-upload')?.click()}
+                        style={{
+                          width: '120px',
+                          height: '120px',
+                          margin: '0 auto 20px',
+                          cursor: 'pointer',
+                          borderRadius: '50%',
+                          overflow: 'hidden',
+                          border: '2px solid #e5e7eb',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: '#f9fafb',
+                        }}
+                      >
+                        {editData.imageUrl ? (
+                          <img
+                            src={editData.imageUrl}
+                            alt="프로필 미리보기"
+                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                          />
+                        ) : (
+                          <svg width="40" height="40" viewBox="0 0 24 24" fill="none">
+                            <path
+                              d="M23 19C23 19.5304 22.7893 20.0391 22.4142 20.4142C22.0391 20.7893 21.5304 21 21 21H3C2.46957 21 1.96086 20.7893 1.58579 20.4142C1.21071 20.0391 1 19.5304 1 19V8C1 7.46957 1.21071 6.96086 1.58579 6.58579C1.96086 6.21071 2.46957 6 3 6H7L9 3H15L17 6H21C21.5304 6 22.0391 6.21071 22.4142 6.58579C22.7893 6.96086 23 7.46957 23 8V19Z"
+                              stroke="#9ca3af"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                            <circle
+                              cx="12"
+                              cy="13"
+                              r="4"
+                              stroke="#9ca3af"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </div>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleImageUpload}
+                        style={{ display: 'none' }}
+                        id="edit-profile-image-upload"
+                      />
+                    </FormField>
+
+                    <FormField>
+                      <FormLabel>닉네임</FormLabel>
                       <FormInput
                         type="text"
-                        value={editData.name}
-                        onChange={(e) => handleInputChange('name', e.target.value)}
-                        placeholder="이름을 입력하세요"
+                        value={editData.nickname}
+                        onChange={(e) => handleInputChange('nickname', e.target.value)}
+                        placeholder="닉네임을 입력하세요"
+                        maxLength={20}
                       />
                     </FormField>
 
@@ -251,12 +401,20 @@ const My = () => {
 
                     <FormField>
                       <FormLabel>기본 위치</FormLabel>
-                      <FormInput
-                        type="text"
-                        value={editData.baseLocation}
-                        onChange={(e) => handleInputChange('baseLocation', e.target.value)}
-                        placeholder="기본 위치를 입력하세요"
-                      />
+                      <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
+                        <FormInput
+                          type="text"
+                          value={sido}
+                          onChange={(e) => setSido(e.target.value)}
+                          placeholder="시/도 (예: 부산광역시)"
+                        />
+                        <FormInput
+                          type="text"
+                          value={sigungu}
+                          onChange={(e) => setSigungu(e.target.value)}
+                          placeholder="시/군/구 (예: 금정구)"
+                        />
+                      </div>
                     </FormField>
 
                     <ButtonGroup>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -7,10 +7,12 @@ import OnboardingStep3 from '@/components/onboarding/OnboardingStep3';
 import OnboardingStep4 from '@/components/onboarding/OnboardingStep4';
 import type { MyProfileState } from '@/store/slices/myProfileSlice';
 import { saveOnboardingProfile } from '@/api/auth';
+import { useFunnel } from '@/hooks/useFunnel';
 
 const Onboarding = () => {
   const navigate = useNavigate();
-  const [currentStep, setCurrentStep] = useState(1);
+  const [Funnel, Step, setStep] = useFunnel(['기본정보', '프로필사진', '추가정보', '완료']);
+
   const [onboardingData, setOnboardingData] = useState<MyProfileState>({
     name: null,
     age: null,
@@ -26,17 +28,11 @@ const Onboarding = () => {
 
   const handleNext = (stepData: Partial<MyProfileState>) => {
     setOnboardingData((prev) => ({ ...prev, ...stepData }));
-    setCurrentStep((prev) => prev + 1);
-  };
-
-  const handlePrev = () => {
-    setCurrentStep((prev) => prev - 1);
   };
 
   const handleComplete = async (finalData: Partial<MyProfileState>) => {
     const completeData = { ...onboardingData, ...finalData };
 
-    // 디버깅을 위한 로그
     console.log('온보딩 완료 데이터:', completeData);
 
     try {
@@ -49,31 +45,52 @@ const Onboarding = () => {
     }
   };
 
-  const renderCurrentStep = () => {
-    switch (currentStep) {
-      case 1:
-        return <OnboardingStep1 data={onboardingData} onNext={handleNext} />;
-      case 2:
-        return <OnboardingStep2 data={onboardingData} onNext={handleNext} onPrev={handlePrev} />;
-      case 3:
-        return <OnboardingStep3 data={onboardingData} onNext={handleNext} onPrev={handlePrev} />;
-      case 4:
-        return (
-          <OnboardingStep4
-            data={onboardingData}
-            onComplete={handleComplete}
-            onPrev={handlePrev}
-            onNext={() => {}}
-          />
-        );
-      default:
-        return <OnboardingStep1 data={onboardingData} onNext={handleNext} />;
-    }
-  };
-
   return (
     <Container>
-      <ContentContanier>{renderCurrentStep()}</ContentContanier>
+      <ContentContanier>
+        <Funnel>
+          <Step name="기본정보">
+            <OnboardingStep1
+              data={onboardingData}
+              onNext={(data) => {
+                handleNext(data);
+                setStep('프로필사진');
+              }}
+            />
+          </Step>
+
+          <Step name="프로필사진">
+            <OnboardingStep2
+              data={onboardingData}
+              onNext={(data) => {
+                handleNext(data);
+                setStep('추가정보');
+              }}
+              onPrev={() => setStep('기본정보')}
+            />
+          </Step>
+
+          <Step name="추가정보">
+            <OnboardingStep3
+              data={onboardingData}
+              onNext={(data) => {
+                handleNext(data);
+                setStep('완료');
+              }}
+              onPrev={() => setStep('프로필사진')}
+            />
+          </Step>
+
+          <Step name="완료">
+            <OnboardingStep4
+              data={onboardingData}
+              onComplete={handleComplete}
+              onPrev={() => setStep('추가정보')}
+              onNext={() => {}}
+            />
+          </Step>
+        </Funnel>
+      </ContentContanier>
     </Container>
   );
 };

--- a/src/pages/RoomCreate.tsx
+++ b/src/pages/RoomCreate.tsx
@@ -7,6 +7,7 @@ import { CommonHeader } from '@/components/common/CommonHeader';
 import { HobbySelector } from '@/components/room_create_page.tsx/HobbySelector';
 import { HashtagInput } from '@/components/room_create_page.tsx/HashtagInput';
 import { StyledInput } from '@/components/room_create_page.tsx/StyledComponents';
+import { TimePicker } from '@/components/room_create_page.tsx/TimePicker';
 import { colors } from '@/style/themes';
 
 const slideUp = keyframes`
@@ -102,12 +103,6 @@ const SubmitButton = styled.button`
   }
 `;
 
-const ErrorMessage = styled.p`
-  font-size: 0.875rem;
-  color: #dc2626;
-  margin-top: 8px;
-`;
-
 const RoomCreate = () => {
   const { formState, hashtags, setHashtags, handleChange, timeError, isFormValid } =
     useCreateForm();
@@ -122,10 +117,22 @@ const RoomCreate = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!isFormValid) return;
+
     const finalFormState = {
-      ...formState,
-      hashtags,
+      name: formState.name,
+      category: formState.category,
+      hashTags: hashtags,
+      capacity: Number(formState.capacity),
+      scoreLimit: Number(formState.scoreLimit),
+      startTime: formState.startTime,
+      endTime: formState.endTime,
+      location: {
+        latitude: formState.location?.lat,
+        longitude: formState.location?.lng,
+        address: formState.location?.name,
+      },
     };
+
     console.log('Final Form Data:', finalFormState);
     alert('방 만들기 요청!');
   };
@@ -156,29 +163,17 @@ const RoomCreate = () => {
         </InputGroup>
 
         <InputGroup>
-          <Label htmlFor="hobby">취미</Label>
-          <HobbySelector value={formState.hobby} onChange={handleChange} />
+          <Label htmlFor="category">카테고리</Label>
+          <HobbySelector value={formState.category} onChange={handleChange} />
         </InputGroup>
 
         <InputGroup>
-          <Label>시작 및 종료 시간</Label>
-          <Grid>
-            <StyledInput
-              name="startTime"
-              type="time"
-              value={formState.startTime}
-              onChange={handleChange}
-              aria-label="시작 시간"
-            />
-            <StyledInput
-              name="endTime"
-              type="time"
-              value={formState.endTime}
-              onChange={handleChange}
-              aria-label="종료 시간"
-            />
-          </Grid>
-          {timeError && <ErrorMessage>{timeError}</ErrorMessage>}
+          <TimePicker
+            startTime={formState.startTime}
+            endTime={formState.endTime}
+            onChange={handleChange}
+            error={timeError}
+          />
         </InputGroup>
 
         <InputGroup>
@@ -199,12 +194,12 @@ const RoomCreate = () => {
             />
           </InputGroup>
           <InputGroup>
-            <Label htmlFor="minTemp">입장 최저 온도</Label>
+            <Label htmlFor="scoreLimit">입장 최소 매너 점수</Label>
             <StyledInput
-              id="minTemp"
-              name="minTemp"
+              id="scoreLimit"
+              name="scoreLimit"
               type="number"
-              value={formState.minTemp}
+              value={formState.scoreLimit}
               onChange={handleChange}
               placeholder="숫자만 입력"
             />

--- a/src/pages/SearchRoom.tsx
+++ b/src/pages/SearchRoom.tsx
@@ -138,7 +138,7 @@ const SearchPageContainer = styled(Container)<{ $closing?: boolean }>`
   bottom: 0;
   margin: 0 auto;
   z-index: 100;
-  animation: ${({ $closing, theme }) => ($closing ? slideDown : slideUp)} 0.4s ease-out forwards;
+  animation: ${({ $closing }) => ($closing ? slideDown : slideUp)} 0.4s ease-out forwards;
 `;
 
 const SearchStatusText = styled.p`

--- a/src/pages/SearchRoom.tsx
+++ b/src/pages/SearchRoom.tsx
@@ -1,53 +1,119 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styled, { keyframes } from 'styled-components';
 import { Container } from '@/style/CommonStyle';
 import { CommonHeader } from '@/components/common/CommonHeader';
-import { useNavigate } from 'react-router-dom';
 import { SearchInput } from '@/components/search_page/SearchInput';
 import { SearchFilters } from '@/components/search_page/SearchFilters';
 import { SearchResultList } from '@/components/search_page/SearchResultList';
+import { getMeetings, type GetMeetingsParams } from '@/api/meeting_list';
+import type { Meeting } from '@/types/meeting';
 
-const dummyData = [
+// ✅ 이 값을 false로 바꾸면 실제 API를 호출하고, true로 바꾸면 아래 mockMeetings를 사용합니다.
+const USE_MOCK_DATA = true;
+
+const mockMeetings: Meeting[] = [
   {
     id: 1,
-    title: '금정구에서 같이 공부할 분!',
-    location: '스타벅스 부산대역점',
+    title: '부산대 앞에서 같이 코딩할 분',
     category: '스터디',
+    hashtags: ['#코딩', '#초보환영'],
+    mannerTemperatureLimit: 30,
+    deadline: '2025-10-16T18:00:00',
+    description: '리액트 스터디원을 모집합니다.',
+    address: '스타벅스 부산대역점',
+    latitude: 35.2335,
+    longitude: 129.081,
+    currentMembers: 2,
+    maxMembers: 5,
   },
-  { id: 2, title: '저녁에 농구하실 분 구합니다', location: '온천천 농구장', category: '운동' },
+  {
+    id: 2,
+    title: '저녁에 농구 한 게임!',
+    category: '운동',
+    hashtags: ['#농구', '#평일저녁'],
+    mannerTemperatureLimit: 20,
+    deadline: '2025-10-15T19:00:00',
+    description: '같이 땀 흘리실 분 구합니다!',
+    address: '온천천 농구장',
+    latitude: 35.2101,
+    longitude: 129.0683,
+    currentMembers: 8,
+    maxMembers: 10,
+  },
   {
     id: 3,
-    title: '주말에 보드게임 하실 분',
-    location: '히어로보드게임카페 부산대점',
-    category: '취미',
+    title: '주말 보드게임 모임',
+    category: '게임',
+    hashtags: ['#보드게임', '#주말'],
+    mannerTemperatureLimit: 36,
+    deadline: '2025-10-18T14:00:00',
+    description: '다양한 보드게임 함께 즐겨요.',
+    address: '히어로보드게임카페 서면점',
+    latitude: 35.1578,
+    longitude: 129.0594,
+    currentMembers: 3,
+    maxMembers: 6,
   },
   {
     id: 4,
-    title: '금정구에서 같이 공부할 분!',
-    location: '스타벅스 부산대역점',
-    category: '스터디',
+    title: '서면에서 마라탕 드실 분',
+    category: '맛집탐방',
+    hashtags: ['#마라탕', '#중식'],
+    mannerTemperatureLimit: 36.5,
+    deadline: '2025-10-17T19:30:00',
+    description: '서면 맛집 같이 가요!',
+    address: '라라관 서면점',
+    latitude: 35.158,
+    longitude: 129.06,
+    currentMembers: 1,
+    maxMembers: 4,
   },
-  { id: 5, title: '저녁에 농구하실 분 구합니다', location: '온천천 농구장', category: '운동' },
+  {
+    id: 5,
+    title: '이번 주 개봉 영화 보러 갈 사람',
+    category: '영화',
+    hashtags: ['#영화', '#최신영화'],
+    mannerTemperatureLimit: 32,
+    deadline: '2025-10-19T20:00:00',
+    description: '영화 보고 치맥하실 분 구합니다.',
+    address: 'CGV 서면',
+    latitude: 35.157,
+    longitude: 129.058,
+    currentMembers: 1,
+    maxMembers: 2,
+  },
   {
     id: 6,
-    title: '주말에 보드게임 하실 분',
-    location: '히어로보드게임카페 부산대점',
-    category: '취미',
-  },
-  {
-    id: 7,
-    title: '금정구에서 같이 공부할 분!',
-    location: '스타벅스 부산대역점',
-    category: '스터디',
-  },
-  { id: 8, title: '저녁에 농구하실 분 구합니다', location: '온천천 농구장', category: '운동' },
-  {
-    id: 9,
-    title: '주말에 보드게임 하실 분',
-    location: '히어로보드게임카페 부산대점',
-    category: '취미',
+    title: '기타 연주 함께 연습해요',
+    category: '기타',
+    hashtags: ['#음악', '#기타'],
+    mannerTemperatureLimit: 25,
+    deadline: '2025-10-20T17:00:00',
+    description: '기타 연습 같이 하실 분!',
+    address: '부산시민공원',
+    latitude: 35.168,
+    longitude: 129.055,
+    currentMembers: 3,
+    maxMembers: 5,
   },
 ];
+
+interface LocationData {
+  lat: number;
+  lng: number;
+}
+
+const useDebounce = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+};
 
 const slideUp = keyframes`
   from { transform: translateY(100%); }
@@ -72,52 +138,116 @@ const SearchPageContainer = styled(Container)<{ $closing?: boolean }>`
   bottom: 0;
   margin: 0 auto;
   z-index: 100;
-  animation: ${({ $closing }) => ($closing ? slideDown : slideUp)} 0.4s ease-out forwards;
+  animation: ${({ $closing, theme }) => ($closing ? slideDown : slideUp)} 0.4s ease-out forwards;
 `;
+
+const SearchStatusText = styled.p`
+  text-align: center;
+  margin-top: 2rem;
+  color: #6b7280;
+`;
+
+const BUSAN_UNIVERSITY_LOCATION: LocationData = {
+  lat: 35.2335,
+  lng: 129.081,
+};
 
 const SearchRoom = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [isClosing, setIsClosing] = useState(false);
   const navigate = useNavigate();
-
+  const location = useLocation();
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedRadius, setSelectedRadius] = useState<string | null>(null);
+  const [results, setResults] = useState<Meeting[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [userLocation, setUserLocation] = useState<LocationData | null>(null);
+  const debouncedSearchQuery = useDebounce(searchQuery, 500);
 
-  const filteredResults = useMemo(() => {
-    let results = dummyData;
+  const searchCenter = useMemo<LocationData | null>(() => {
+    return location.state?.searchCenter || null;
+  }, [location.state]);
 
-    if (searchQuery) {
-      results = results.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase()),
-      );
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setUserLocation({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        });
+      },
+      (err) => {
+        console.error('위치 정보를 가져오는데 실패했습니다:', err);
+        setUserLocation(BUSAN_UNIVERSITY_LOCATION);
+      },
+    );
+  }, []);
+
+  const fetchMeetings = useCallback(async () => {
+    if (searchCenter && !selectedRadius) {
+      setResults([]);
+      return;
     }
+    setIsLoading(true);
+    setError(null);
 
-    if (selectedCategories.length > 0) {
-      results = results.filter((item) => selectedCategories.includes(item.category));
+    if (USE_MOCK_DATA) {
+      setTimeout(() => {
+        let data = mockMeetings;
+        if (debouncedSearchQuery) {
+          data = data.filter((m) =>
+            m.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase()),
+          );
+        }
+        if (selectedCategories.length > 0) {
+          data = data.filter((m) => selectedCategories.includes(m.category));
+        }
+        setResults(data);
+        setIsLoading(false);
+      }, 500);
+    } else {
+      try {
+        const params: GetMeetingsParams = {};
+        const locationForApi = searchCenter || userLocation;
+        if (debouncedSearchQuery) params.name = debouncedSearchQuery;
+        if (selectedCategories.length > 0) params.hobby = selectedCategories.join(',');
+        if (locationForApi) {
+          params.latitude = locationForApi.lat;
+          params.longitude = locationForApi.lng;
+          if (selectedRadius) {
+            params.radius = parseInt(selectedRadius.replace('km', ''), 10);
+          }
+        }
+        const data = await getMeetings(params);
+        setResults(data);
+      } catch (err: any) {
+        setError(err.message || '모임을 불러오는 데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
     }
+  }, [debouncedSearchQuery, selectedCategories, selectedRadius, searchCenter, userLocation]);
 
-    return results;
-  }, [searchQuery, selectedCategories]);
+  useEffect(() => {
+    if (userLocation || searchCenter) {
+      fetchMeetings();
+    }
+  }, [fetchMeetings, userLocation, searchCenter]);
 
-  const handleBackButtonClick = () => {
-    setIsClosing(true);
-  };
-
+  const handleBackButtonClick = () => setIsClosing(true);
   const handleCategoryClick = (category: string) => {
     setSelectedCategories((prev) =>
       prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category],
     );
   };
-
   const handleRadiusClick = (radius: string) => {
     setSelectedRadius((prev) => (prev === radius ? null : radius));
   };
 
   useEffect(() => {
     if (isClosing) {
-      const timer = setTimeout(() => {
-        navigate(-1);
-      }, 400);
+      const timer = setTimeout(() => navigate(-1), 400);
       return () => clearTimeout(timer);
     }
   }, [isClosing, navigate]);
@@ -132,7 +262,16 @@ const SearchRoom = () => {
         onCategoryClick={handleCategoryClick}
         onRadiusClick={handleRadiusClick}
       />
-      <SearchResultList results={filteredResults} />
+      {isLoading && <SearchStatusText>검색 중...</SearchStatusText>}
+      {error && <SearchStatusText style={{ color: 'red' }}>{error}</SearchStatusText>}
+      {!isLoading && !error && (
+        <SearchResultList
+          results={results.map((meeting) => ({
+            ...meeting,
+            location: meeting.address,
+          }))}
+        />
+      )}
     </SearchPageContainer>
   );
 };

--- a/src/store/slices/myProfileSlice.ts
+++ b/src/store/slices/myProfileSlice.ts
@@ -8,7 +8,7 @@ export interface MyProfileState {
   nickname: string | null;
   imageUrl: string | undefined;
   description: string | null;
-  baseLocation: string | null;
+  baseLocation: string | { sidoName: string; sigunguName: string } | null;
   temperature: number | null;
   likes: number | null;
   dislikes: number | null;

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,0 +1,25 @@
+// 뱃지 타입 정의
+export interface Badge {
+  badgeId: string;
+  name: string;
+  description: string;
+  iconUrl: string;
+  code: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 페이지 정보
+export interface PageInfo {
+  size: number;
+  number: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+// 뱃지 목록 응답
+export interface BadgeListResponse {
+  content: Badge[];
+  page: PageInfo;
+}
+

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,7 +1,7 @@
 // src/utils/tokenStorage.ts
-const ACCESS_KEY = "accessToken";
-const REFRESH_KEY = "refreshToken";
-const PROFILE_KEY = "myProfile";
+const ACCESS_KEY = 'accessToken';
+const REFRESH_KEY = 'refreshToken';
+const PROFILE_KEY = 'myProfile';
 
 export const saveTokens = (accessToken: string, refreshToken: string) => {
   localStorage.setItem(ACCESS_KEY, accessToken);


### PR DESCRIPTION
## 📝 PR 유형

- [x] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. GitHub Actions 배포 스크립트에 CloudFront 배포 단계에 캐시 무효화(invalidation) 절차를 추가하여 최신 리소스가 즉시 반영되도록 개선하였습니다. 또한 HTML 파일 업로드 시 Cache-Control: no-cache, no-store, must-revalidate 메타데이터를 설정하여 브라우저 캐싱을 방지하고 항상 최신 HTML을 로드하도록 설정하였습니다.

   <img width="942" height="238" alt="스크린샷 2025-10-17 오후 5 40 16" src="https://github.com/user-attachments/assets/1d652833-cc8a-4042-94e1-cd05b8695a29" />

2. 모임 생성 페이지의 세부 카테고리를 삭제하고, 방 생성 시간 단위를 30분으로 설정했습니다.

   <img width="393" height="220" alt="스크린샷 2025-10-17 오후 5 32 34" src="https://github.com/user-attachments/assets/aa9f32f2-94b0-4a45-82c3-3d0fef8b9c19" />

   <img width="392" height="191" alt="스크린샷 2025-10-17 오후 5 33 20" src="https://github.com/user-attachments/assets/2c8acc61-2da0-4b89-9c50-5846faf1a68b" />

3. 메인 페이지에 필터링을 추가하여 바로 원하는 조건의 검색이 가능하도록 했습니다. 

   <img width="393" height="851" alt="스크린샷 2025-10-17 오후 5 46 20" src="https://github.com/user-attachments/assets/c994e598-bf07-4a6a-b6fe-9248bec69b68" />

4. 마이페이지에서 사용자 이름이 표시되지 않던 문제와 프로필 편집 기능이 정상적으로 동작하지 않던 오류를 수정하였으며, 새로운 뱃지 영역과 로그아웃 기능을 추가하였습니다

5. 온보딩 과정을 useFunnel을 활용하여 리팩토링하였으며, 지역 입력 방식을 시도와 시군구로 분리하였습니다.

6. WebSocket + STOMP를 통한 기본 채팅 송수신 기능을 완성했습니다.
   다음은 서로 다른 두 테스트 계정을 각각 사파리와 크롬으로 로그인하여 진행한 테스트 결과입니다.
   (테스트 계정 1 - ID: user@test.com, PW: testpass1212! / 테스트 계정 2 - ID: alice@test.com, PW: testpass1212!)

   <img width="1792" height="1120" alt="스크린샷 2025-10-17 오후 5 07 28" src="https://github.com/user-attachments/assets/663a8270-535e-4cbb-913d-455975c01627" />

   <img width="1792" height="1120" alt="스크린샷 2025-10-17 오후 5 07 20" src="https://github.com/user-attachments/assets/fe4ebcdb-c8f6-4ad3-8a52-559db649c1b7" />

## 📄 의존성 추가/변경 사항

N/A

## 💬 기타 사항

1. 채팅 메세지의 송수신 로직에는 문제가 없었으나, 이를 렌더링하는 부분에서 문제가 있습니다. 추후 수정 예정입니다.
2. 현재 회원가입 과정에 이메일 인증 절차를 추가하였습니다. 사용자가 회원가입 페이지에서 이메일과 비밀번호를 입력하면, 인증 링크가 포함된 메일이 발송되며, 사용자가 해당 링크를 클릭하면 인증과 가입이 완료되고 로그인 화면으로 다시 리다이렉트됩니다. 이후 로그인을 하고 나면 초기 프로필 설정을 위한 온보딩 페이지로 이동하도록 설계할 예정입니다. 지금 배포된 링크에서는 메일만 받아 볼 수 있습니다.
3. API 관련 로직을 다음과 같은 구조로 관리하고자 합니다.

   <img width="300" height="197" alt="스크린샷 2025-10-17 오후 6 32 29" src="https://github.com/user-attachments/assets/b4bce2ac-9f86-4ac1-b6ee-b92f3b86c30b" />

   혹시 더 나은 패턴이 있는지 궁금합니다.

## 📂 참고 자료

> N/A
