### PR TITLE
[REFACTOR] 웹소캣 액션 메세지 재정의

### DIFF
--- a/src/pages/MeetingRoom.tsx
+++ b/src/pages/MeetingRoom.tsx
@@ -112,12 +112,12 @@ const MeetingRoom = () => {
   useEffect(() => {
     if (!newAction || !myIdRef.current) return;
     console.log('newAction', newAction);
+    handleSocketAction('JOIN', newAction, navigate, myIdRef.current, setChatMessages);
+    handleSocketAction('EXIT', newAction, navigate, myIdRef.current, setChatMessages);
+    handleSocketAction('NEAR_STARTED', newAction, navigate);
     handleSocketAction('STARTED', newAction, navigate, undefined, setIsStarted);
     handleSocketAction('NEAR_END', newAction, navigate);
     handleSocketAction('END', newAction, navigate);
-    handleSocketAction('END_BY_SYSTEM', newAction, navigate);
-    handleSocketAction('JOIN', newAction, navigate, myIdRef.current, setChatMessages);
-    handleSocketAction('EXIT', newAction, navigate, myIdRef.current, setChatMessages);
     handleSocketAction('MODIFIED', newAction, navigate);
     handleSocketAction('CANCELED', newAction, navigate);
   }, [newAction]);

--- a/src/types/meeting_room_page/actionMessage.ts
+++ b/src/types/meeting_room_page/actionMessage.ts
@@ -1,15 +1,16 @@
 export type ActionType =
-  | 'ENTER'
-  | 'JOIN'
-  | 'LEAVE'
-  | 'EXIT'
-  | 'MODIFIED'
-  | 'CANCELED'
-  | 'MESSAGE'
-  | 'STARTED'
-  | 'NEAR_END'
-  | 'END'
-  | 'END_BY_SYSTEM'
+  | 'JOIN' // 모임 참여
+  | 'EXIT' // 모임 탈퇴
+  | 'KICKED' // 강제 퇴장
+  | 'ENTER' // 입장
+  | 'LEAVE' // 퇴장
+  | 'MESSAGE' // 채팅 메세지
+  | 'MODIFIED' // 모임방 수정
+  | 'CANCELED' // 모집 취소
+  | 'NEAR_STARTED' // 모임 시작 임박 알림
+  | 'STARTED' // 모임 시작(OPEN -> IN_PROGRESS)
+  | 'NEAR_END' // 모임 종료 임박 알림
+  | 'END' // 모임 종료
   | undefined;
 
 export type DefaultActionMessage = {

--- a/src/utils/handleSocketAction.ts
+++ b/src/utils/handleSocketAction.ts
@@ -34,6 +34,13 @@ export const handleSocketAction = <T>(
   lastActionTime = now;
 
   switch (expectedAction) {
+    case 'NEAR_STARTED': {
+      toast.info('모집 마감까지 10분 남았습니다!', {
+        id: 'NEAR_STARTED',
+      } as any);
+      return false;
+    }
+
     case 'STARTED': {
       toast.success('모임이 시작되었습니다.', {
         id: 'STARTED',
@@ -43,27 +50,18 @@ export const handleSocketAction = <T>(
     }
 
     case 'NEAR_END': {
-      toast.warn('모집 종료까지 10분 남았습니다!', {
+      toast.info('모임 종료까지 10분 남았습니다!', {
         id: 'NEAR_END',
       } as any);
-      navigate('/participant-evaluation');
-      return false;
+      return true;
     }
 
     case 'END': {
-      toast.info('모임이 종료되었습니다.', {
+      toast.success('모임이 종료되었습니다.', {
         id: 'END',
         position: 'bottom-center',
       } as any);
       navigate('/participant-evaluation');
-      return false;
-    }
-
-    case 'END_BY_SYSTEM': {
-      toast.info('모집 시간이 마감되었습니다.', {
-        id: 'END_BY_SYSTEM',
-      } as any);
-      navigate('/home');
       return false;
     }
 


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [ ] ✨ Feature (새로운 기능 추가)
- [x] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 변경된 웹소켓 액션 메시지에 따라 프론트엔드 로직을 수정합니다.
   'NEAR_STARTED': 모임 시작 10분 전 시간 임박 알림
   'STARTED': 모임 시작 (OPEN -> IN_PROGRESS)
   'NEAR_END': 모임 종료 10분전 시간 임박 알림
   'END': 모임 종료


## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #97 

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
