### PR TITLE
[FEAT] 메인페이지 API 연동 및 모임참가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-
 import Landing from '@/pages/Landing';
 import Login from '@/pages/Login';
 import Signup from '@/pages/Signup';
@@ -29,7 +28,6 @@ function App() {
         <Route path="/kakaoLogin" element={<KakaoLogin />} />
         <Route path="/email-verification" element={<EmailVerification />} />
 
-        {/* 로그인 필요*/}
         <Route element={<ProtectedRoute />}>
           <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/home" element={<Home />} />
@@ -38,7 +36,7 @@ function App() {
           <Route path="/create-room/:update?" element={<RoomCreate />} />
           <Route path="/create-room/location" element={<LocationPicker />} />
           <Route path="/search-room" element={<SearchRoom />} />
-          <Route path="/meeting-room" element={<MeetingRoom />} />
+          <Route path="/meeting-room/:roomId" element={<MeetingRoom />} />
           <Route path="/participant-evaluation" element={<ParticipantEvaluation />} />
         </Route>
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+
 import Landing from '@/pages/Landing';
 import Login from '@/pages/Login';
 import Signup from '@/pages/Signup';
@@ -13,7 +14,6 @@ import LocationPicker from '@/pages/LocationPicker';
 import ParticipantEvaluation from './pages/ParticipantEvaluation';
 import My from './pages/My';
 import UserProfile from './pages/UserProfile';
-import EmailVerification from './pages/EmailVerification';
 import ProtectedRoute from '@/components/common/ProtectedRoute';
 import { ToastContainer } from 'react-toastify';
 
@@ -26,17 +26,17 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/kakaoLogin" element={<KakaoLogin />} />
-        <Route path="/email-verification" element={<EmailVerification />} />
-
+        <Route path="/onboarding" element={<Onboarding />} />
         <Route element={<ProtectedRoute />}>
-          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/home" element={<Home />} />
           <Route path="/my" element={<My />} />
           <Route path="/user/:userId" element={<UserProfile />} />
           <Route path="/create-room/:update?" element={<RoomCreate />} />
           <Route path="/create-room/location" element={<LocationPicker />} />
           <Route path="/search-room" element={<SearchRoom />} />
+          <Route path="/meeting-room" element={<MeetingRoom />} />
           <Route path="/meeting-room/:roomId" element={<MeetingRoom />} />
+
           <Route path="/participant-evaluation" element={<ParticipantEvaluation />} />
         </Route>
       </Routes>

--- a/src/api/services/meetup.service.ts
+++ b/src/api/services/meetup.service.ts
@@ -9,7 +9,10 @@ export interface GetMeetingsParams {
   radius?: number;
 }
 
+const baseURL = import.meta.env.VITE_API_BASE_URL as string | undefined;
+
 export const getMeetings = async (params: GetMeetingsParams): Promise<Meeting[]> => {
-  const response = await api.get<Meeting[]>('/api/meetings', { params });
+  const url = baseURL ? `${baseURL}/api/meetups/geo` : '/api/meetups/geo';
+  const response = await api.get<Meeting[]>(url, { params });
   return response.data;
 };

--- a/src/api/services/meetup.service.ts
+++ b/src/api/services/meetup.service.ts
@@ -3,7 +3,7 @@ import api from '../clients/axiosInstance';
 
 export interface GetMeetingsParams {
   name?: string;
-  hobby?: string;
+  category?: string;
   latitude?: number;
   longitude?: number;
   radius?: number;

--- a/src/components/home_page/MeetingDetailModal.tsx
+++ b/src/components/home_page/MeetingDetailModal.tsx
@@ -60,7 +60,7 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
     }
 
     if (isInRoom) {
-      toast.error('이미 다른 모임에 참여 중입니다.');
+      toast.error('이미 모임에 참여 중입니다.');
       return;
     }
 

--- a/src/components/home_page/MeetingDetailModal.tsx
+++ b/src/components/home_page/MeetingDetailModal.tsx
@@ -15,6 +15,9 @@ import {
   Title,
   Category,
 } from '@/components/home_page/ModalStyle';
+import { joinMeetUp } from '@/api/services/meetup_room.service';
+import { useMyProfile } from '@/hooks/useMyProfile';
+import { useMyCurrentMeeting } from '@/hooks/useMyCurrentMeeting';
 
 interface MeetingDetailModalProps {
   meeting: Meeting;
@@ -24,9 +27,19 @@ interface MeetingDetailModalProps {
 
 export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailModalProps) => {
   const [isVisible, setIsVisible] = useState(false);
+  const [isJoining, setIsJoining] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  const { myProfile, isLoadingProfile } = useMyProfile();
+  const { myMeeting, isLoadingMeeting, refetchMyMeeting } = useMyCurrentMeeting();
+
+  const userTemperature = myProfile?.temperature || 0;
+  const isInRoom = !!myMeeting;
+  const isLoading = isLoadingProfile || isLoadingMeeting;
 
   useEffect(() => {
     if (isOpen) {
+      setJoinError(null);
       const timer = setTimeout(() => setIsVisible(true), 10);
       return () => clearTimeout(timer);
     }
@@ -37,9 +50,47 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
     setTimeout(onClose, 300);
   };
 
+  const handleEnterRoom = async () => {
+    if (!myProfile) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+
+    if (isInRoom) {
+      alert('이미 다른 모임에 참여 중입니다.');
+      return;
+    }
+
+    const limit = meeting.scoreLimit;
+    if (userTemperature < limit) {
+      alert(
+        `이 모임은 매너 점수 ${limit}점 이상이어야 입장할 수 있습니다. (현재 ${userTemperature}점)`,
+      );
+      return;
+    }
+
+    setIsJoining(true);
+    setJoinError(null);
+    try {
+      await joinMeetUp(String(meeting.id));
+      alert(`${meeting.name} 방에 성공적으로 입장했습니다!`);
+      await refetchMyMeeting();
+      handleClose();
+    } catch (err: any) {
+      const errorMessage = err.message || '알 수 없는 오류';
+      setJoinError(errorMessage);
+      alert(`입장 실패: ${errorMessage}`);
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
   if (!isOpen) {
     return null;
   }
+
+  //
+  const tags = meeting.hashTags || [];
 
   return (
     <>
@@ -48,29 +99,37 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
         <Handle />
         <Content>
           <Category>{meeting.category}</Category>
-          <Title>{meeting.title}</Title>
+          <Title>{meeting.name}</Title>
           <HashtagContainer>
-            {meeting.hashtags.map((tag) => (
+            {/* */}
+            {tags.map((tag) => (
               <Hashtag key={tag}>{tag}</Hashtag>
             ))}
           </HashtagContainer>
           <InfoGrid>
             <InfoItem>
-              <InfoLabel>🌡️ 제한 매너 온도</InfoLabel>
-              <InfoValue>{meeting.mannerTemperatureLimit}°C 이상</InfoValue>
+              <InfoLabel>🌡️ 제한 매너 점수</InfoLabel>
+              <InfoValue>{meeting.scoreLimit}°C 이상</InfoValue>
             </InfoItem>
             <InfoItem>
               <InfoLabel>👥 인원</InfoLabel>
               <InfoValue>
-                {meeting.currentMembers} / {meeting.maxMembers}명
+                {meeting.participantCount} / {meeting.capacity}명
               </InfoValue>
             </InfoItem>
             <InfoItem>
               <InfoLabel>⏰ 마감 시간</InfoLabel>
-              <InfoValue>{meeting.deadline}</InfoValue>
+              <InfoValue>{meeting.endAt}</InfoValue>
             </InfoItem>
           </InfoGrid>
-          <EnterButton onClick={() => alert(`${meeting.title} 방에 입장합니다!`)}>입장</EnterButton>
+          <EnterButton onClick={handleEnterRoom} disabled={isJoining || isLoading}>
+            {isLoading ? '정보 확인 중...' : isJoining ? '입장 중...' : '입장'}
+          </EnterButton>
+          {joinError && (
+            <div style={{ color: 'red', fontSize: '14px', marginTop: '10px', textAlign: 'center' }}>
+              {joinError}
+            </div>
+          )}
         </Content>
       </ModalContainer>
     </>

--- a/src/components/home_page/MeetingDetailModal.tsx
+++ b/src/components/home_page/MeetingDetailModal.tsx
@@ -18,7 +18,8 @@ import {
 import { joinMeetUp } from '@/api/services/meetup_room.service';
 import { useMyProfile } from '@/hooks/useMyProfile';
 import { useMyCurrentMeeting } from '@/hooks/useMyCurrentMeeting';
-
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 interface MeetingDetailModalProps {
   meeting: Meeting;
   onClose: () => void;
@@ -29,6 +30,8 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
   const [isVisible, setIsVisible] = useState(false);
   const [isJoining, setIsJoining] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
+
+  const navigate = useNavigate();
 
   const { myProfile, isLoadingProfile } = useMyProfile();
   const { myMeeting, isLoadingMeeting, refetchMyMeeting } = useMyCurrentMeeting();
@@ -52,18 +55,18 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
 
   const handleEnterRoom = async () => {
     if (!myProfile) {
-      alert('로그인이 필요합니다.');
+      toast.error('로그인이 필요합니다.');
       return;
     }
 
     if (isInRoom) {
-      alert('이미 다른 모임에 참여 중입니다.');
+      toast.error('이미 다른 모임에 참여 중입니다.');
       return;
     }
 
     const limit = meeting.scoreLimit;
     if (userTemperature < limit) {
-      alert(
+      toast.error(
         `이 모임은 매너 점수 ${limit}점 이상이어야 입장할 수 있습니다. (현재 ${userTemperature}점)`,
       );
       return;
@@ -73,13 +76,15 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
     setJoinError(null);
     try {
       await joinMeetUp(String(meeting.id));
-      alert(`${meeting.name} 방에 성공적으로 입장했습니다!`);
+      toast.success(`${meeting.name} 방에 성공적으로 입장했습니다!`);
       await refetchMyMeeting();
+
       handleClose();
+      navigate(`/meeting-room/${meeting.id}`);
     } catch (err: any) {
       const errorMessage = err.message || '알 수 없는 오류';
       setJoinError(errorMessage);
-      alert(`입장 실패: ${errorMessage}`);
+      toast.error(`입장 실패: ${errorMessage}`);
     } finally {
       setIsJoining(false);
     }
@@ -89,7 +94,6 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
     return null;
   }
 
-  //
   const tags = meeting.hashTags || [];
 
   return (
@@ -101,7 +105,6 @@ export const MeetingDetailModal = ({ meeting, onClose, isOpen }: MeetingDetailMo
           <Category>{meeting.category}</Category>
           <Title>{meeting.name}</Title>
           <HashtagContainer>
-            {/* */}
             {tags.map((tag) => (
               <Hashtag key={tag}>{tag}</Hashtag>
             ))}

--- a/src/components/home_page/MeetingIcon.tsx
+++ b/src/components/home_page/MeetingIcon.tsx
@@ -29,8 +29,20 @@ interface MeetingIconProps {
 }
 
 const MeetingIcon = ({ category, className }: MeetingIconProps) => {
-  const iconKey = categoryMap[category];
-  const IconComponent = iconComponents[iconKey] || DefaultIcon;
+  const directKey = category.trim().toUpperCase() as MeetingCategory;
+
+  const mappedKey = categoryMap[category.trim()];
+
+  let IconComponent = iconComponents[directKey];
+
+  if (!IconComponent) {
+    IconComponent = iconComponents[mappedKey];
+  }
+
+  if (!IconComponent) {
+    IconComponent = DefaultIcon;
+  }
+
   return <IconComponent className={className} />;
 };
 

--- a/src/components/home_page/ModalStyle.tsx
+++ b/src/components/home_page/ModalStyle.tsx
@@ -22,7 +22,7 @@ export const ModalContainer = styled.div<{ $isVisible: boolean }>`
   width: 100%;
   max-width: 720px;
   /* max-height: 80vh; */
-  height: 70vh;
+  height: 60vh;
   background-color: white;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;

--- a/src/hooks/useMeetingMarkers.ts
+++ b/src/hooks/useMeetingMarkers.ts
@@ -14,10 +14,23 @@ export const useMeetingMarkers = (
     markersRef.current.forEach((marker) => marker.setMap(null));
     //markersRef.current = [];
 
-    if (!map || !window.kakao || !Array.isArray(meetings)) return;
+    if (!map || !window.kakao || !Array.isArray(meetings) || meetings.length === 0) {
+      return;
+    }
 
     const newMarkers = meetings.map((meeting) => {
-      const position = new window.kakao.maps.LatLng(meeting.latitude, meeting.longitude);
+      //
+      if (!meeting.location || !meeting.location.latitude || !meeting.location.longitude) {
+        console.warn('경고: 모임 데이터에 위치(location) 정보가 없습니다.', meeting);
+        return null;
+      }
+
+      //
+      const position = new window.kakao.maps.LatLng(
+        meeting.location.latitude,
+        meeting.location.longitude,
+      );
+
       const markerContainer = document.createElement('div');
       markerContainer.className = 'custom-div-icon';
       markerContainer.style.cursor = 'pointer';
@@ -38,11 +51,12 @@ export const useMeetingMarkers = (
         position: position,
         content: markerContainer,
         yAnchor: 1,
+        zIndex: 10,
       });
       customOverlay.setMap(map);
       return customOverlay;
     });
 
-    markersRef.current = newMarkers;
+    markersRef.current = newMarkers.filter((marker) => marker !== null);
   }, [map, meetings, onMarkerClick]);
 };

--- a/src/hooks/useMeetings.ts
+++ b/src/hooks/useMeetings.ts
@@ -44,29 +44,21 @@ export const useMeetings = (
       };
 
       if (selectedCategories.length > 0) {
-        //
-        //
-        //
         const apiCategories = selectedCategories.map(
           (korCategory) => CATEGORY_API_MAP[korCategory] || korCategory,
         );
-        params.category = apiCategories.join(','); //
+        params.category = apiCategories.join(',');
       }
 
       if (selectedRadius) {
         params.radius = parseInt(selectedRadius.replace('km', ''), 10);
       }
 
-<<<<<<< HEAD
-      const meetingData = await getMeetings(params);
-      setMeetings(meetingData);
-=======
       const response = await api.get('/api/meetups/geo', { params });
 
       const meetingData = response.data;
 
       setMeetings(Array.isArray(meetingData) ? meetingData : []);
->>>>>>> 96ab381 (feature:다건조회 api연동(#91))
     } catch (err: any) {
       console.error('모임 정보를 불러오는 데 실패했습니다.', err);
 
@@ -94,15 +86,10 @@ export const useMeetings = (
   }, [map, fetchMeetings]);
 
   useEffect(() => {
-<<<<<<< HEAD
-    fetchMeetings();
-  }, [fetchMeetings]);
-=======
     if (map) {
       fetchMeetings();
     }
   }, [selectedCategories, selectedRadius, map, fetchMeetings]);
->>>>>>> 96ab381 (feature:다건조회 api연동(#91))
 
   return { meetings, isLoading, error };
 };

--- a/src/hooks/useMeetings.ts
+++ b/src/hooks/useMeetings.ts
@@ -10,9 +10,21 @@ interface ApiMeetingsParams {
   radius?: number;
 }
 
+//
+//
+//
+const CATEGORY_API_MAP: { [key: string]: string } = {
+  스터디: 'STUDY',
+  운동: 'SPORTS',
+  게임: 'GAME',
+  맛집탐방: 'MUKBANG',
+  영화: 'MOVIE',
+};
+//
+
 export const useMeetings = (
   map: any,
-  selectedCategories: string[],
+  selectedCategories: string[], //
   selectedRadius: string | null,
 ) => {
   const [meetings, setMeetings] = useState<Meeting[]>([]);
@@ -32,7 +44,13 @@ export const useMeetings = (
       };
 
       if (selectedCategories.length > 0) {
-        params.category = selectedCategories.join(',');
+        //
+        //
+        //
+        const apiCategories = selectedCategories.map(
+          (korCategory) => CATEGORY_API_MAP[korCategory] || korCategory,
+        );
+        params.category = apiCategories.join(','); //
       }
 
       if (selectedRadius) {

--- a/src/hooks/useMeetings.ts
+++ b/src/hooks/useMeetings.ts
@@ -1,7 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Meeting } from '@/types/meeting';
 import { ERROR_MESSAGES } from '@/constants/messages';
-import { getMeetings } from '@/api/services/meetup.service';
+import api from '@/api/clients/axiosInstance';
+
+interface ApiMeetingsParams {
+  latitude: number;
+  longitude: number;
+  category?: string;
+  radius?: number;
+}
 
 export const useMeetings = (
   map: any,
@@ -18,23 +25,37 @@ export const useMeetings = (
     setError(null);
     try {
       const center = map.getCenter();
-      const params: any = {
+
+      const params: ApiMeetingsParams = {
         latitude: center.getLat(),
         longitude: center.getLng(),
       };
+
       if (selectedCategories.length > 0) {
-        params.hobby = selectedCategories.join(',');
-      }
-      if (selectedRadius) {
-        params.radius = parseInt(selectedRadius.replace('km', ''), 10) * 1000;
+        params.category = selectedCategories.join(',');
       }
 
+      if (selectedRadius) {
+        params.radius = parseInt(selectedRadius.replace('km', ''), 10);
+      }
+
+<<<<<<< HEAD
       const meetingData = await getMeetings(params);
       setMeetings(meetingData);
+=======
+      const response = await api.get('/api/meetups/geo', { params });
+
+      const meetingData = response.data;
+
+      setMeetings(Array.isArray(meetingData) ? meetingData : []);
+>>>>>>> 96ab381 (feature:다건조회 api연동(#91))
     } catch (err: any) {
       console.error('모임 정보를 불러오는 데 실패했습니다.', err);
+
+      const errorMessage = err.message || '알 수 없는 오류';
+
       setError(
-        err.response?.status === 401
+        errorMessage.includes('401')
           ? ERROR_MESSAGES.LOGIN_REQUIRED
           : ERROR_MESSAGES.MEETING_FETCH_FAILED,
       );
@@ -46,6 +67,7 @@ export const useMeetings = (
 
   useEffect(() => {
     if (map) {
+      fetchMeetings();
       const listener = window.kakao.maps.event.addListener(map, 'idle', fetchMeetings);
       return () => {
         window.kakao.maps.event.removeListener(map, 'idle', listener);
@@ -54,8 +76,15 @@ export const useMeetings = (
   }, [map, fetchMeetings]);
 
   useEffect(() => {
+<<<<<<< HEAD
     fetchMeetings();
   }, [fetchMeetings]);
+=======
+    if (map) {
+      fetchMeetings();
+    }
+  }, [selectedCategories, selectedRadius, map, fetchMeetings]);
+>>>>>>> 96ab381 (feature:다건조회 api연동(#91))
 
   return { meetings, isLoading, error };
 };

--- a/src/hooks/useMeetingsSearch.ts
+++ b/src/hooks/useMeetingsSearch.ts
@@ -13,7 +13,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#코딩', '#초보환영'],
     mannerTemperatureLimit: 30,
     deadline: '2025-10-16T18:00:00',
-    description: '리액트 스터디원을 모집합니다.',
     address: '스타벅스 부산대역점',
     latitude: 35.2335,
     longitude: 129.081,
@@ -27,7 +26,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#농구', '#평일저녁'],
     mannerTemperatureLimit: 20,
     deadline: '2025-10-15T19:00:00',
-    description: '같이 땀 흘리실 분 구합니다!',
     address: '온천천 농구장',
     latitude: 35.2101,
     longitude: 129.0683,
@@ -41,7 +39,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#보드게임', '#주말'],
     mannerTemperatureLimit: 36,
     deadline: '2025-10-18T14:00:00',
-    description: '다양한 보드게임 함께 즐겨요.',
     address: '히어로보드게임카페 서면점',
     latitude: 35.1578,
     longitude: 129.0594,
@@ -55,7 +52,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#마라탕', '#중식'],
     mannerTemperatureLimit: 36.5,
     deadline: '2025-10-17T19:30:00',
-    description: '서면 맛집 같이 가요!',
     address: '라라관 서면점',
     latitude: 35.158,
     longitude: 129.06,
@@ -69,7 +65,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#영화', '#최신영화'],
     mannerTemperatureLimit: 32,
     deadline: '2025-10-19T20:00:00',
-    description: '영화 보고 치맥하실 분 구합니다.',
     address: 'CGV 서면',
     latitude: 35.157,
     longitude: 129.058,
@@ -83,7 +78,6 @@ const mockMeetings: Meeting[] = [
     hashtags: ['#음악', '#기타'],
     mannerTemperatureLimit: 25,
     deadline: '2025-10-20T17:00:00',
-    description: '기타 연습 같이 하실 분!',
     address: '부산시민공원',
     latitude: 35.168,
     longitude: 129.055,
@@ -161,7 +155,7 @@ export const useMeetingsSearch = ({
           const params: GetMeetingsParams = {};
 
           if (debouncedQuery) params.name = debouncedQuery;
-          if (categories.length > 0) params.hobby = categories.join(',');
+          if (categories.length > 0) params.category = categories.join(',');
 
           params.latitude = locationForApi.lat;
           params.longitude = locationForApi.lng;

--- a/src/hooks/useMyCurrentMeeting.ts
+++ b/src/hooks/useMyCurrentMeeting.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getMyJoinedMeetup } from '@/api/services/meetup_room.service';
+import type { MeetupResponseDTO } from '@/api/types/meeting_room.dto';
+
+export const useMyCurrentMeeting = () => {
+  const [myMeeting, setMyMeeting] = useState<MeetupResponseDTO | null>(null);
+  const [isLoadingMeeting, setIsLoadingMeeting] = useState(true);
+  const [meetingError, setMeetingError] = useState<string | null>(null);
+
+  const fetchMyMeeting = useCallback(async () => {
+    try {
+      setIsLoadingMeeting(true);
+      const meetingData = await getMyJoinedMeetup();
+      setMyMeeting(meetingData);
+    } catch (err: any) {
+      setMyMeeting(null);
+      setMeetingError(err.message || '참여 중인 모임 정보를 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoadingMeeting(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMyMeeting();
+  }, [fetchMyMeeting]);
+
+  return { myMeeting, isLoadingMeeting, meetingError, refetchMyMeeting: fetchMyMeeting };
+};

--- a/src/hooks/useMyProfile.ts
+++ b/src/hooks/useMyProfile.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import { getMyProfile } from '@/api/services/profile.service';
+import type { MyProfileState } from '@/store/slices/myProfileSlice';
+
+export const useMyProfile = () => {
+  const [myProfile, setMyProfile] = useState<MyProfileState | null>(null);
+  const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        setIsLoadingProfile(true);
+        const profileData = await getMyProfile();
+        setMyProfile(profileData);
+      } catch (err: any) {
+        setProfileError(err.message || '프로필을 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoadingProfile(false);
+      }
+    };
+
+    fetchProfile();
+  }, []);
+
+  return { myProfile, isLoadingProfile, profileError };
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -187,7 +187,11 @@ const Home = () => {
 
           {isSearchOpen && <Overlay />}
           {selectedMeeting && (
-            <MeetingDetailModal meeting={selectedMeeting} onClose={handleCloseModal} />
+            <MeetingDetailModal
+              meeting={selectedMeeting}
+              onClose={handleCloseModal}
+              isOpen={true}
+            />
           )}
         </MapArea>
         <BottomNav />

--- a/src/pages/RoomCreate.tsx
+++ b/src/pages/RoomCreate.tsx
@@ -223,7 +223,7 @@ const RoomCreate = () => {
   useEffect(() => {
     if (isClosing) {
       const timer = setTimeout(() => {
-        navigate(-1);
+        navigate('/home');
       }, 400);
       return () => clearTimeout(timer);
     }

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -1,14 +1,19 @@
-export interface Meeting {
-  id: number;
-  title: string;
-  category: string;
-  hashtags: string[];
-  mannerTemperatureLimit: number;
-  deadline: string;
-  description: string;
-  address: string;
-  latitude: number;
+export interface MeetingLocation {
   longitude: number;
-  currentMembers: number;
-  maxMembers: number;
+  latitude: number;
+  address: string;
+}
+
+export interface Meeting {
+  id: string;
+  name: string;
+  category: string;
+  hashTags: string[];
+  scoreLimit: number;
+  endAt: string;
+  location: MeetingLocation;
+  participantCount: number;
+  capacity: number;
+
+  [key: string]: any;
 }


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🛠️ Bug Fix (버그 수정)
- [x] ✨ Feature (새로운 기능 추가)
- [ ] ⚙️ Refactor (코드 리팩토링)
- [ ] 📄 Docs (문서 수정)
- [ ] 🪛 Chore (빌드, 설정, 기타 변경)

## 🔧 작업 내용

1. 모임 api 연동

2. 불러온 모임에 대해 핀 찍기 + 카테고리에 맞는 이미지 입히기
   <img width="422" height="445" alt="image" src="https://github.com/user-attachments/assets/eef20aa2-083e-4672-91b8-4d256d8abbb6" />

3. 모임 참가
   <img width="532" height="432" alt="image" src="https://github.com/user-attachments/assets/7c53426f-55cf-41f3-8109-20636f887830" />

## 📄 의존성 추가/변경 사항

N/A

## 🔍 관련 이슈

Closes #91

## 💬 기타 사항

N/A

## 📂 참고 자료

> N/A
